### PR TITLE
Fix lint warnings (1/n)

### DIFF
--- a/.github/workflows/presubmits.yml
+++ b/.github/workflows/presubmits.yml
@@ -56,9 +56,8 @@ jobs:
       #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       #  run: make license-check
 
-      # TODO(presubmits): Re-enable linter
-      #- name: Run linter
-      #  run: make lint
+      - name: Run linter
+        run: make lint
 
   test:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,7 @@ linters:
     - staticcheck
     - stylecheck
     - thelper
-    - typecheck
+    #- typecheck
     - unconvert
     - unused
     - varcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,7 +31,7 @@ linters:
     - gocyclo
     - godot
     - godox
-    #- goerr113
+    - goerr113
     - gofmt
     - gofumpt
     - goheader

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,7 +55,7 @@ linters:
     - unconvert
     - unused
     - whitespace
-    #- wrapcheck
+    - wrapcheck
 linters-settings:
   errcheck:
     check-type-assertions: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,11 +15,12 @@ issues:
 linters:
   disable-all: true
   enable:
+    # TODO(lint): Uncomment linters and fix warnings
     - asciicheck
     - deadcode
     - depguard
     - dogsled
-    #- errcheck
+    - errcheck
     - errorlint
     - exhaustive
     - exportloopref

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,15 +40,15 @@ linters:
     - goprintffuncname
     - gosec
     #- gosimple
-    - govet
-    - ineffassign
+    #- govet
+    #- ineffassign
     #- lll
     - makezero
     - misspell
     - nakedret
     #- nestif
     - predeclared
-    - staticcheck
+    #- staticcheck
     - stylecheck
     - thelper
     #- typecheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,7 @@ linters:
     #- staticcheck
     - stylecheck
     - thelper
-    #- typecheck
+    - typecheck
     - unconvert
     - unused
     - whitespace

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,131 @@
+---
+run:
+  concurrency: 6
+  deadline: 5m
+issues:
+  # Maximum issues count per one linter.
+  # Set to 0 to disable.
+  # Default: 50
+  max-issues-per-linter: 0
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
+  max-same-issues: 0
+  new-from-rev: ""
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - deadcode
+    - depguard
+    - dogsled
+    - errcheck
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - gci
+    - gochecknoinits
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - godox
+    - goerr113
+    - gofmt
+    - gofumpt
+    - goheader
+    - goimports
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - makezero
+    - misspell
+    - nakedret
+    - nestif
+    - predeclared
+    - staticcheck
+    - stylecheck
+    - thelper
+    - typecheck
+    - unconvert
+    - unused
+    - varcheck
+    - whitespace
+    - wrapcheck
+linters-settings:
+  errcheck:
+    check-type-assertions: true
+    check-blank: true
+  exhaustive:
+    # https://golangci-lint.run/usage/linters/#exhaustive
+    default-signifies-exhaustive: true
+  govet:
+    enable:
+      - fieldalignment
+  godox:
+    keywords:
+      - BUG
+      - FIXME
+      - HACK
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/uwu-tools/gh-jira-issue-sync)
+  gocritic:
+    enabled-checks:
+      # Diagnostic
+      - appendAssign
+      - badCond
+      - caseOrder
+      - codegenComment
+      - commentedOutCode
+      - deprecatedComment
+      - dupBranchBody
+      - dupCase
+      - dupSubExpr
+      - exitAfterDefer
+      - flagName
+      - nilValReturn
+      - weakCond
+      - octalLiteral
+
+      # Performance
+      - appendCombine
+      - hugeParam
+      - rangeExprCopy
+      - rangeValCopy
+
+      # Style
+      - boolExprSimplify
+      - captLocal
+      - commentFormatting
+      - commentedOutImport
+      - defaultCaseOrder
+      - docStub
+      - elseif
+      - emptyFallthrough
+      - hexLiteral
+      - ifElseChain
+      - methodExprCall
+      - singleCaseSwitch
+      - typeAssertChain
+      - typeSwitchVar
+      - underef
+      - unlabelStmt
+      - unlambda
+
+      # Opinionated
+      - builtinShadow
+      - importShadow
+      - initClause
+      - nestingReduce
+      - paramTypeCombine
+      - ptrToRefParam
+      - typeUnparen
+      - unnecessaryBlock

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,19 +19,19 @@ linters:
     - deadcode
     - depguard
     - dogsled
-    - errcheck
+    #- errcheck
     - errorlint
     - exhaustive
     - exportloopref
     - gci
-    - gochecknoinits
+    #- gochecknoinits
     - gocognit
     - goconst
-    - gocritic
+    #- gocritic
     - gocyclo
     - godot
     - godox
-    - goerr113
+    #- goerr113
     - gofmt
     - gofumpt
     - goheader
@@ -39,14 +39,14 @@ linters:
     - gomodguard
     - goprintffuncname
     - gosec
-    - gosimple
+    #- gosimple
     - govet
     - ineffassign
-    - lll
+    #- lll
     - makezero
     - misspell
     - nakedret
-    - nestif
+    #- nestif
     - predeclared
     - staticcheck
     - stylecheck
@@ -56,7 +56,7 @@ linters:
     - unused
     - varcheck
     - whitespace
-    - wrapcheck
+    #- wrapcheck
 linters-settings:
   errcheck:
     check-type-assertions: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,6 @@ linters:
   enable:
     # TODO(lint): Uncomment linters and fix warnings
     - asciicheck
-    - deadcode
     - depguard
     - dogsled
     - errcheck
@@ -55,7 +54,6 @@ linters:
     #- typecheck
     - unconvert
     - unused
-    - varcheck
     - whitespace
     #- wrapcheck
 linters-settings:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GOARCH=$(shell go env GOARCH)
 SOURCES := $(shell find . -name '*.go')
 LD_FLAGS=-ldflags "-X $(REPO_PATH)/cmd.Version=$(VERSION)"
 
-GOLANGCI_VERSION = 1.49.0
+GOLANGCI_VERSION = 1.50.1
 
 build: bin/$(PROJ)
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -108,7 +108,7 @@ func (c *Config) LoadJIRAConfig(client jira.Client) error {
 		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			c.log.Errorf("error occurred trying to read error body: %s", err)
-			return err
+			return fmt.Errorf("reading Jira project: %w", err)
 		}
 
 		c.log.Debugf("Error body: %s", body)
@@ -242,23 +242,23 @@ func (c *Config) SaveConfig() error {
 
 	var cf configFile
 	if err := c.cmdConfig.Unmarshal(&cf); err != nil {
-		return err
+		return fmt.Errorf("unmarshalling config: %w", err)
 	}
 
 	b, err := json.MarshalIndent(cf, "", "  ")
 	if err != nil {
-		return err
+		return fmt.Errorf("marshalling config: %w", err)
 	}
 
 	f, err := os.OpenFile(c.cmdConfig.ConfigFileUsed(), os.O_RDWR|os.O_TRUNC|os.O_CREATE, 0o644)
 	if err != nil {
-		return err
+		return fmt.Errorf("opening config file %s: %w", c.cmdConfig.ConfigFileUsed(), err)
 	}
 	defer f.Close()
 
 	_, err = f.WriteString(string(b))
 	if err != nil {
-		return err
+		return fmt.Errorf("writing config: %w", err)
 	}
 
 	return nil
@@ -458,13 +458,13 @@ func (c Config) getFieldIDs(client jira.Client) (fields, error) {
 	c.log.Debug("Collecting field IDs.")
 	req, err := client.NewRequest("GET", "/rest/api/2/field", nil)
 	if err != nil {
-		return fields{}, err
+		return fields{}, fmt.Errorf("getting fields: %w", err)
 	}
 	jFields := new([]jiraField)
 
 	_, err = client.Do(req, jFields)
 	if err != nil {
-		return fields{}, err
+		return fields{}, fmt.Errorf("getting field IDs: %w", err)
 	}
 
 	fieldIDs := fields{}

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -85,7 +85,7 @@ func NewConfig(cmd *cobra.Command) (Config, error) {
 	}
 
 	config.cmdConfig = *newViper("issue-sync", config.cmdFile)
-	config.cmdConfig.BindPFlags(cmd.Flags())
+	config.cmdConfig.BindPFlags(cmd.Flags()) //nolint:errcheck
 
 	config.cmdFile = config.cmdConfig.ConfigFileUsed()
 
@@ -241,7 +241,9 @@ func (c *Config) SaveConfig() error {
 	c.cmdConfig.Set("since", time.Now().Format(dateFormat))
 
 	var cf configFile
-	c.cmdConfig.Unmarshal(&cf)
+	if err := c.cmdConfig.Unmarshal(&cf); err != nil {
+		return err
+	}
 
 	b, err := json.MarshalIndent(cf, "", "  ")
 	if err != nil {
@@ -254,7 +256,10 @@ func (c *Config) SaveConfig() error {
 	}
 	defer f.Close()
 
-	f.WriteString(string(b))
+	_, err = f.WriteString(string(b))
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"strings"
@@ -105,7 +105,7 @@ func (c *Config) LoadJIRAConfig(client jira.Client) error {
 	if err != nil {
 		c.log.Errorf("error retrieving JIRA project; check key and credentials. Error: %s", err)
 		defer res.Body.Close()
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			c.log.Errorf("error occurred trying to read error body: %s", err)
 			return err

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -418,7 +418,7 @@ func (c *Config) validateConfig() error {
 
 	since, err := time.Parse(dateFormat, sinceStr)
 	if err != nil {
-		return errors.New("Since date must be in ISO-8601 format")
+		return errors.New("`since` date must be in ISO-8601 format")
 	}
 	c.since = since
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -103,11 +103,11 @@ func NewConfig(cmd *cobra.Command) (Config, error) {
 func (c *Config) LoadJIRAConfig(client jira.Client) error {
 	proj, res, err := client.Project.Get(c.cmdConfig.GetString("jira-project"))
 	if err != nil {
-		c.log.Errorf("Error retrieving JIRA project; check key and credentials. Error: %v", err)
+		c.log.Errorf("error retrieving JIRA project; check key and credentials. Error: %s", err)
 		defer res.Body.Close()
 		body, err := ioutil.ReadAll(res.Body)
 		if err != nil {
-			c.log.Errorf("Error occurred trying to read error body: %v", err)
+			c.log.Errorf("error occurred trying to read error body: %s", err)
 			return err
 		}
 
@@ -348,15 +348,15 @@ func (c *Config) validateConfig() error {
 
 		jUser := c.cmdConfig.GetString("jira-user")
 		if jUser == "" {
-			return errors.New("Jira username required")
+			return errors.New("jira username required")
 		}
 
 		jPass := c.cmdConfig.GetString("jira-pass")
 		if jPass == "" {
-			fmt.Print("Enter your JIRA password: ")
-			bytePass, err := term.ReadPassword(int(syscall.Stdin))
+			fmt.Print("Enter your Jira password: ")
+			bytePass, err := term.ReadPassword(syscall.Stdin)
 			if err != nil {
-				return errors.New("JIRA password required")
+				return errors.New("jira password required")
 			}
 			fmt.Println()
 			c.cmdConfig.Set("jira-pass", string(bytePass))
@@ -366,12 +366,12 @@ func (c *Config) validateConfig() error {
 
 		token := c.cmdConfig.GetString("jira-token")
 		if token == "" {
-			return errors.New("JIRA access token required")
+			return errors.New("jira access token required")
 		}
 
 		secret := c.cmdConfig.GetString("jira-secret")
 		if secret == "" {
-			return errors.New("JIRA access token secret required")
+			return errors.New("jira access token secret required")
 		}
 
 		consumerKey := c.cmdConfig.GetString("jira-consumer-key")

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -20,13 +20,13 @@ import (
 	"golang.org/x/term"
 )
 
-// dateFormat is the format used for the `since` configuration parameter
+// dateFormat is the format used for the `since` configuration parameter.
 const dateFormat = "2006-01-02T15:04:05-0700"
 
-// defaultLogLevel is the level logrus should default to if the configured option can't be parsed
+// defaultLogLevel is the level logrus should default to if the configured option can't be parsed.
 const defaultLogLevel = logrus.InfoLevel
 
-// fieldKey is an enum-like type to represent the customfield ID keys
+// fieldKey is an enum-like type to represent the customfield ID keys.
 type fieldKey int
 
 const (
@@ -38,7 +38,7 @@ const (
 	LastISUpdate   fieldKey = iota
 )
 
-// fields represents the custom field IDs of the JIRA custom fields we care about
+// fields represents the custom field IDs of the JIRA custom fields we care about.
 type fields struct {
 	githubID       string
 	githubNumber   string
@@ -107,7 +107,7 @@ func (c *Config) LoadJIRAConfig(client jira.Client) error {
 		defer res.Body.Close()
 		body, err := ioutil.ReadAll(res.Body)
 		if err != nil {
-			c.log.Errorf("Error occured trying to read error body: %v", err)
+			c.log.Errorf("Error occurred trying to read error body: %v", err)
 			return err
 		}
 
@@ -155,7 +155,7 @@ func (c Config) IsDryRun() bool {
 	return c.cmdConfig.GetBool("dry-run")
 }
 
-// IsDaemon returns whether the application is running as a daemon
+// IsDaemon returns whether the application is running as a daemon.
 func (c Config) IsDaemon() bool {
 	return c.cmdConfig.GetDuration("period") != 0
 }
@@ -248,7 +248,7 @@ func (c *Config) SaveConfig() error {
 		return err
 	}
 
-	f, err := os.OpenFile(c.cmdConfig.ConfigFileUsed(), os.O_RDWR|os.O_TRUNC|os.O_CREATE, 0644)
+	f, err := os.OpenFile(c.cmdConfig.ConfigFileUsed(), os.O_RDWR|os.O_TRUNC|os.O_CREATE, 0o644)
 	if err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -28,18 +29,18 @@ var RootCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		config, err := cfg.NewConfig(cmd)
 		if err != nil {
-			return err
+			return fmt.Errorf("creating new config: %w", err)
 		}
 
 		log := config.GetLogger()
 
 		jiraClient, err := clients.NewJIRAClient(&config)
 		if err != nil {
-			return err
+			return fmt.Errorf("creating Jira client: %w", err)
 		}
 		ghClient, err := clients.NewGitHubClient(config)
 		if err != nil {
-			return err
+			return fmt.Errorf("creating GitHub client: %w", err)
 		}
 
 		for {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -21,7 +21,7 @@ import (
 
 var Version = "undefined"
 
-// versionCmd represents the version command
+// versionCmd represents the version command.
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Returns the current version of issue-sync",

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,13 +3,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (

--- a/lib/clients/github.go
+++ b/lib/clients/github.go
@@ -3,7 +3,6 @@ package clients
 import (
 	"context"
 	"fmt"
-
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -115,7 +114,6 @@ func (g realGHClient) GetUser(login string) (github.User, error) {
 	u, _, err := g.request(func() (interface{}, *github.Response, error) {
 		return g.client.Users.Get(context.Background(), login)
 	})
-
 	if err != nil {
 		log.Errorf("Error retrieving GitHub user %s. Error: %v", login, err)
 	}

--- a/lib/clients/github.go
+++ b/lib/clients/github.go
@@ -44,7 +44,7 @@ func (g realGHClient) ListIssues() ([]github.Issue, error) {
 
 	for page := 1; page <= pages; page++ {
 		is, res, err := g.request(func() (interface{}, *github.Response, error) {
-			return g.client.Issues.ListByRepo(ctx, user, repo, &github.IssueListByRepoOptions{
+			return g.client.Issues.ListByRepo(ctx, user, repo, &github.IssueListByRepoOptions{ //nolint:wrapcheck
 				Since:     g.config.GetSinceParam(),
 				State:     "all",
 				Sort:      "created",
@@ -89,7 +89,7 @@ func (g realGHClient) ListComments(issue github.Issue) ([]*github.IssueComment, 
 	ctx := context.Background()
 	user, repo := g.config.GetRepo()
 	c, _, err := g.request(func() (interface{}, *github.Response, error) {
-		return g.client.Issues.ListComments(ctx, user, repo, issue.GetNumber(), &github.IssueListCommentsOptions{
+		return g.client.Issues.ListComments(ctx, user, repo, issue.GetNumber(), &github.IssueListCommentsOptions{ //nolint:wrapcheck
 			Sort:      github.String("created"),
 			Direction: github.String("asc"),
 		})
@@ -112,7 +112,7 @@ func (g realGHClient) GetUser(login string) (github.User, error) {
 	log := g.config.GetLogger()
 
 	u, _, err := g.request(func() (interface{}, *github.Response, error) {
-		return g.client.Users.Get(context.Background(), login)
+		return g.client.Users.Get(context.Background(), login) //nolint:wrapcheck
 	})
 	if err != nil {
 		log.Errorf("Error retrieving GitHub user %s. Error: %v", login, err)
@@ -135,7 +135,7 @@ func (g realGHClient) GetRateLimits() (github.RateLimits, error) {
 	ctx := context.Background()
 
 	rl, _, err := g.request(func() (interface{}, *github.Response, error) {
-		return g.client.RateLimits(ctx)
+		return g.client.RateLimits(ctx) //nolint:wrapcheck
 	})
 	if err != nil {
 		log.Errorf("Error connecting to GitHub; check your token. Error: %w", err)
@@ -180,7 +180,7 @@ func (g realGHClient) request(f func() (interface{}, *github.Response, error)) (
 		log.Errorf("Error performing operation; retrying in %v: %v", duration, err)
 	})
 
-	return ret, res, backoffErr
+	return ret, res, fmt.Errorf("backoff error: %w", backoffErr)
 }
 
 // NewGitHubClient creates a GitHubClient and returns it; which
@@ -209,7 +209,7 @@ func NewGitHubClient(config cfg.Config) (GitHubClient, error) {
 	// Make a request so we can check that we can connect fine.
 	_, err := ret.GetRateLimits()
 	if err != nil {
-		return realGHClient{}, err
+		return realGHClient{}, fmt.Errorf("getting GitHub rate limits: %w", err)
 	}
 	log.Debug("Successfully connected to GitHub.")
 

--- a/lib/clients/github.go
+++ b/lib/clients/github.go
@@ -61,7 +61,7 @@ func (g realGHClient) ListIssues() ([]github.Issue, error) {
 		issuePointers, ok := is.([]*github.Issue)
 		if !ok {
 			log.Errorf("Get GitHub issues did not return issues! Got: %v", is)
-			return nil, fmt.Errorf("get GitHub issues failed: expected []*github.Issue; got %T", is)
+			return nil, fmt.Errorf("get GitHub issues failed: expected []*github.Issue; got %T", is) //nolint:goerr113
 		}
 
 		var issuePage []github.Issue
@@ -101,7 +101,7 @@ func (g realGHClient) ListComments(issue github.Issue) ([]*github.IssueComment, 
 	comments, ok := c.([]*github.IssueComment)
 	if !ok {
 		log.Errorf("Get GitHub comments did not return comments! Got: %v", c)
-		return nil, fmt.Errorf("get GitHub comments failed: expected []*github.IssueComment; got %T", c)
+		return nil, fmt.Errorf("get GitHub comments failed: expected []*github.IssueComment; got %T", c) //nolint:goerr113
 	}
 
 	return comments, nil
@@ -121,7 +121,7 @@ func (g realGHClient) GetUser(login string) (github.User, error) {
 	user, ok := u.(*github.User)
 	if !ok {
 		log.Errorf("Get GitHub user did not return user! Got: %v", u)
-		return github.User{}, fmt.Errorf("get GitHub user failed: expected *github.User; got %T", u)
+		return github.User{}, fmt.Errorf("get GitHub user failed: expected *github.User; got %T", u) //nolint:goerr113
 	}
 
 	return *user, nil
@@ -144,7 +144,7 @@ func (g realGHClient) GetRateLimits() (github.RateLimits, error) {
 	rate, ok := rl.(*github.RateLimits)
 	if !ok {
 		log.Errorf("Get GitHub rate limits did not return rate limits! Got: %v", rl)
-		return github.RateLimits{}, fmt.Errorf("get GitHub rate limits failed: expected *github.RateLimits; got %T", rl)
+		return github.RateLimits{}, fmt.Errorf("get GitHub rate limits failed: expected *github.RateLimits; got %T", rl) //nolint:goerr113
 	}
 
 	return *rate, nil

--- a/lib/clients/github.go
+++ b/lib/clients/github.go
@@ -101,7 +101,7 @@ func (g realGHClient) ListComments(issue github.Issue) ([]*github.IssueComment, 
 	comments, ok := c.([]*github.IssueComment)
 	if !ok {
 		log.Errorf("Get GitHub comments did not return comments! Got: %v", c)
-		return nil, fmt.Errorf("Get GitHub comments failed: expected []*github.IssueComment; got %T", c)
+		return nil, fmt.Errorf("get GitHub comments failed: expected []*github.IssueComment; got %T", c)
 	}
 
 	return comments, nil
@@ -121,7 +121,7 @@ func (g realGHClient) GetUser(login string) (github.User, error) {
 	user, ok := u.(*github.User)
 	if !ok {
 		log.Errorf("Get GitHub user did not return user! Got: %v", u)
-		return github.User{}, fmt.Errorf("Get GitHub user failed: expected *github.User; got %T", u)
+		return github.User{}, fmt.Errorf("get GitHub user failed: expected *github.User; got %T", u)
 	}
 
 	return *user, nil
@@ -138,7 +138,7 @@ func (g realGHClient) GetRateLimits() (github.RateLimits, error) {
 		return g.client.RateLimits(ctx)
 	})
 	if err != nil {
-		log.Errorf("Error connecting to GitHub; check your token. Error: %v", err)
+		log.Errorf("Error connecting to GitHub; check your token. Error: %w", err)
 		return github.RateLimits{}, err
 	}
 	rate, ok := rl.(*github.RateLimits)

--- a/lib/clients/github.go
+++ b/lib/clients/github.go
@@ -144,7 +144,7 @@ func (g realGHClient) GetRateLimits() (github.RateLimits, error) {
 	rate, ok := rl.(*github.RateLimits)
 	if !ok {
 		log.Errorf("Get GitHub rate limits did not return rate limits! Got: %v", rl)
-		return github.RateLimits{}, fmt.Errorf("Get GitHub rate limits failed: expected *github.RateLimits; got %T", rl)
+		return github.RateLimits{}, fmt.Errorf("get GitHub rate limits failed: expected *github.RateLimits; got %T", rl)
 	}
 
 	return *rate, nil

--- a/lib/clients/jira.go
+++ b/lib/clients/jira.go
@@ -84,7 +84,10 @@ func NewJIRAClient(config *cfg.Config) (JIRAClient, error) {
 
 	log.Debug("JIRA clients initialized")
 
-	config.LoadJIRAConfig(*client)
+	err = config.LoadJIRAConfig(*client)
+	if err != nil {
+		return nil, err
+	}
 
 	if config.IsDryRun() {
 		j = dryrunJIRAClient{

--- a/lib/clients/jira.go
+++ b/lib/clients/jira.go
@@ -3,7 +3,7 @@ package clients
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -31,7 +31,7 @@ const maxJQLIssueLength = 100
 func getErrorBody(config cfg.Config, res *jira.Response) error {
 	log := config.GetLogger()
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Errorf("Error occurred trying to read error body: %w", err)
 		return err
@@ -179,7 +179,7 @@ func (j realJIRAClient) GetIssue(key string) (jira.Issue, error) {
 	issue, ok := i.(*jira.Issue)
 	if !ok {
 		log.Errorf("Get JIRA issue did not return issue! Got %v", i)
-		return jira.Issue{}, fmt.Errorf("Get JIRA issue failed: expected *jira.Issue; got %T", i)
+		return jira.Issue{}, fmt.Errorf("get JIRA issue failed: expected *jira.Issue; got %T", i)
 	}
 
 	return *issue, nil
@@ -201,7 +201,7 @@ func (j realJIRAClient) CreateIssue(issue jira.Issue) (jira.Issue, error) {
 	is, ok := i.(*jira.Issue)
 	if !ok {
 		log.Errorf("Create JIRA issue did not return issue! Got: %v", i)
-		return jira.Issue{}, fmt.Errorf("Create JIRA issue failed: expected *jira.Issue; got %T", i)
+		return jira.Issue{}, fmt.Errorf("create JIRA issue failed: expected *jira.Issue; got %T", i)
 	}
 
 	return *is, nil
@@ -223,7 +223,7 @@ func (j realJIRAClient) UpdateIssue(issue jira.Issue) (jira.Issue, error) {
 	is, ok := i.(*jira.Issue)
 	if !ok {
 		log.Errorf("Update JIRA issue did not return issue! Got: %v", i)
-		return jira.Issue{}, fmt.Errorf("Update JIRA issue failed: expected *jira.Issue; got %T", i)
+		return jira.Issue{}, fmt.Errorf("update JIRA issue failed: expected *jira.Issue; got %T", i)
 	}
 
 	return *is, nil
@@ -273,7 +273,7 @@ func (j realJIRAClient) CreateComment(issue jira.Issue, comment github.IssueComm
 	co, ok := com.(*jira.Comment)
 	if !ok {
 		log.Errorf("Create JIRA comment did not return comment! Got: %v", com)
-		return jira.Comment{}, fmt.Errorf("Create JIRA comment failed: expected *jira.Comment; got %T", com)
+		return jira.Comment{}, fmt.Errorf("create JIRA comment failed: expected *jira.Comment; got %T", com)
 	}
 	return *co, nil
 }
@@ -330,7 +330,7 @@ func (j realJIRAClient) UpdateComment(issue jira.Issue, id string, comment githu
 	co, ok := com.(*jira.Comment)
 	if !ok {
 		log.Errorf("Update JIRA comment did not return comment! Got: %v", com)
-		return jira.Comment{}, fmt.Errorf("Update JIRA comment failed: expected *jira.Comment; got %T", com)
+		return jira.Comment{}, fmt.Errorf("update JIRA comment failed: expected *jira.Comment; got %T", com)
 	}
 	return *co, nil
 }
@@ -468,7 +468,7 @@ func (j dryrunJIRAClient) GetIssue(key string) (jira.Issue, error) {
 	issue, ok := i.(*jira.Issue)
 	if !ok {
 		log.Errorf("Get JIRA issue did not return issue! Got %v", i)
-		return jira.Issue{}, fmt.Errorf("Get JIRA issue failed: expected *jira.Issue; got %T", i)
+		return jira.Issue{}, fmt.Errorf("get JIRA issue failed: expected *jira.Issue; got %T", i)
 	}
 
 	return *issue, nil

--- a/lib/clients/jira.go
+++ b/lib/clients/jira.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
-
 	"time"
 
 	"github.com/andygrunwald/go-jira"
@@ -34,7 +33,7 @@ func getErrorBody(config cfg.Config, res *jira.Response) error {
 	defer res.Body.Close()
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		log.Errorf("Error occured trying to read error body: %v", err)
+		log.Errorf("Error occurred trying to read error body: %v", err)
 		return err
 	}
 	log.Debugf("Error body: %s", body)
@@ -382,7 +381,7 @@ var newlineReplaceRegex = regexp.MustCompile("\r?\n")
 
 // truncate is a utility function to replace all the newlines in
 // the string with the characters "\n", then truncate it to no
-// more than 50 characters
+// more than 50 characters.
 func truncate(s string, length int) string {
 	if s == "" {
 		return "empty"

--- a/lib/clients/jira.go
+++ b/lib/clients/jira.go
@@ -1,7 +1,6 @@
 package clients
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -37,7 +36,7 @@ func getErrorBody(config cfg.Config, res *jira.Response) error {
 		return fmt.Errorf("reading error body: %w", err)
 	}
 	log.Debugf("Error body: %s", body)
-	return errors.New(string(body))
+	return fmt.Errorf("reading error body: %s", string(body)) //nolint:goerr113
 }
 
 // JIRAClient is a wrapper around the JIRA API clients library we
@@ -143,7 +142,7 @@ func (j realJIRAClient) ListIssues(ids []int) ([]jira.Issue, error) {
 	jiraIssues, ok := ji.([]jira.Issue)
 	if !ok {
 		log.Errorf("Get JIRA issues did not return issues! Got: %v", ji)
-		return nil, fmt.Errorf("get JIRA issues failed: expected []jira.Issue; got %T", ji)
+		return nil, fmt.Errorf("get JIRA issues failed: expected []jira.Issue; got %T", ji) //nolint:goerr113
 	}
 
 	var issues []jira.Issue
@@ -182,7 +181,7 @@ func (j realJIRAClient) GetIssue(key string) (jira.Issue, error) {
 	issue, ok := i.(*jira.Issue)
 	if !ok {
 		log.Errorf("Get JIRA issue did not return issue! Got %v", i)
-		return jira.Issue{}, fmt.Errorf("get JIRA issue failed: expected *jira.Issue; got %T", i)
+		return jira.Issue{}, fmt.Errorf("get JIRA issue failed: expected *jira.Issue; got %T", i) //nolint:goerr113
 	}
 
 	return *issue, nil
@@ -204,7 +203,7 @@ func (j realJIRAClient) CreateIssue(issue jira.Issue) (jira.Issue, error) {
 	is, ok := i.(*jira.Issue)
 	if !ok {
 		log.Errorf("Create JIRA issue did not return issue! Got: %v", i)
-		return jira.Issue{}, fmt.Errorf("create JIRA issue failed: expected *jira.Issue; got %T", i)
+		return jira.Issue{}, fmt.Errorf("create JIRA issue failed: expected *jira.Issue; got %T", i) //nolint:goerr113
 	}
 
 	return *is, nil
@@ -226,7 +225,7 @@ func (j realJIRAClient) UpdateIssue(issue jira.Issue) (jira.Issue, error) {
 	is, ok := i.(*jira.Issue)
 	if !ok {
 		log.Errorf("Update JIRA issue did not return issue! Got: %v", i)
-		return jira.Issue{}, fmt.Errorf("update JIRA issue failed: expected *jira.Issue; got %T", i)
+		return jira.Issue{}, fmt.Errorf("update JIRA issue failed: expected *jira.Issue; got %T", i) //nolint:goerr113
 	}
 
 	return *is, nil
@@ -276,7 +275,7 @@ func (j realJIRAClient) CreateComment(issue jira.Issue, comment github.IssueComm
 	co, ok := com.(*jira.Comment)
 	if !ok {
 		log.Errorf("Create JIRA comment did not return comment! Got: %v", com)
-		return jira.Comment{}, fmt.Errorf("create JIRA comment failed: expected *jira.Comment; got %T", com)
+		return jira.Comment{}, fmt.Errorf("create JIRA comment failed: expected *jira.Comment; got %T", com) //nolint:goerr113
 	}
 	return *co, nil
 }
@@ -333,7 +332,7 @@ func (j realJIRAClient) UpdateComment(issue jira.Issue, id string, comment githu
 	co, ok := com.(*jira.Comment)
 	if !ok {
 		log.Errorf("Update JIRA comment did not return comment! Got: %v", com)
-		return jira.Comment{}, fmt.Errorf("update JIRA comment failed: expected *jira.Comment; got %T", com)
+		return jira.Comment{}, fmt.Errorf("update JIRA comment failed: expected *jira.Comment; got %T", com) //nolint:goerr113
 	}
 	return *co, nil
 }
@@ -430,7 +429,7 @@ func (j dryrunJIRAClient) ListIssues(ids []int) ([]jira.Issue, error) {
 	jiraIssues, ok := ji.([]jira.Issue)
 	if !ok {
 		log.Errorf("Get JIRA issues did not return issues! Got: %v", ji)
-		return nil, fmt.Errorf("get JIRA issues failed: expected []jira.Issue; got %T", ji)
+		return nil, fmt.Errorf("get JIRA issues failed: expected []jira.Issue; got %T", ji) //nolint:goerr113
 	}
 
 	var issues []jira.Issue
@@ -471,7 +470,7 @@ func (j dryrunJIRAClient) GetIssue(key string) (jira.Issue, error) {
 	issue, ok := i.(*jira.Issue)
 	if !ok {
 		log.Errorf("Get JIRA issue did not return issue! Got %v", i)
-		return jira.Issue{}, fmt.Errorf("get JIRA issue failed: expected *jira.Issue; got %T", i)
+		return jira.Issue{}, fmt.Errorf("get JIRA issue failed: expected *jira.Issue; got %T", i) //nolint:goerr113
 	}
 
 	return *issue, nil

--- a/lib/clients/jira.go
+++ b/lib/clients/jira.go
@@ -33,7 +33,7 @@ func getErrorBody(config cfg.Config, res *jira.Response) error {
 	defer res.Body.Close()
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		log.Errorf("Error occurred trying to read error body: %v", err)
+		log.Errorf("Error occurred trying to read error body: %w", err)
 		return err
 	}
 	log.Debugf("Error body: %s", body)
@@ -65,7 +65,7 @@ func NewJIRAClient(config *cfg.Config) (JIRAClient, error) {
 	if !config.IsBasicAuth() {
 		oauth, err = newJIRAHTTPClient(*config)
 		if err != nil {
-			log.Errorf("Error getting OAuth config: %v", err)
+			log.Errorf("Error getting OAuth config: %w", err)
 			return dryrunJIRAClient{}, err
 		}
 	}
@@ -74,7 +74,7 @@ func NewJIRAClient(config *cfg.Config) (JIRAClient, error) {
 
 	client, err := jira.NewClient(oauth, config.GetConfigString("jira-uri"))
 	if err != nil {
-		log.Errorf("Error initializing JIRA clients; check your base URI. Error: %v", err)
+		log.Errorf("Error initializing JIRA clients; check your base URI. Error: %w", err)
 		return dryrunJIRAClient{}, err
 	}
 
@@ -134,7 +134,7 @@ func (j realJIRAClient) ListIssues(ids []int) ([]jira.Issue, error) {
 		return j.client.Issue.Search(jql, nil)
 	})
 	if err != nil {
-		log.Errorf("Error retrieving JIRA issues: %v", err)
+		log.Errorf("Error retrieving JIRA issues: %w", err)
 		return nil, getErrorBody(j.config, res)
 	}
 	jiraIssues, ok := ji.([]jira.Issue)
@@ -173,7 +173,7 @@ func (j realJIRAClient) GetIssue(key string) (jira.Issue, error) {
 		return j.client.Issue.Get(key, nil)
 	})
 	if err != nil {
-		log.Errorf("Error retrieving JIRA issue: %v", err)
+		log.Errorf("Error retrieving JIRA issue: %w", err)
 		return jira.Issue{}, getErrorBody(j.config, res)
 	}
 	issue, ok := i.(*jira.Issue)
@@ -195,7 +195,7 @@ func (j realJIRAClient) CreateIssue(issue jira.Issue) (jira.Issue, error) {
 		return j.client.Issue.Create(&issue)
 	})
 	if err != nil {
-		log.Errorf("Error creating JIRA issue: %v", err)
+		log.Errorf("Error creating JIRA issue: %w", err)
 		return jira.Issue{}, getErrorBody(j.config, res)
 	}
 	is, ok := i.(*jira.Issue)
@@ -324,7 +324,7 @@ func (j realJIRAClient) UpdateComment(issue jira.Issue, id string, comment githu
 		return nil, res, err
 	})
 	if err != nil {
-		log.Errorf("Error updating comment: %v", err)
+		log.Errorf("Error updating comment: %w", err)
 		return jira.Comment{}, getErrorBody(j.config, res)
 	}
 	co, ok := com.(*jira.Comment)
@@ -421,7 +421,7 @@ func (j dryrunJIRAClient) ListIssues(ids []int) ([]jira.Issue, error) {
 		return j.client.Issue.Search(jql, nil)
 	})
 	if err != nil {
-		log.Errorf("Error retrieving JIRA issues: %v", err)
+		log.Errorf("Error retrieving JIRA issues: %w", err)
 		return nil, getErrorBody(j.config, res)
 	}
 	jiraIssues, ok := ji.([]jira.Issue)
@@ -462,7 +462,7 @@ func (j dryrunJIRAClient) GetIssue(key string) (jira.Issue, error) {
 		return j.client.Issue.Get(key, nil)
 	})
 	if err != nil {
-		log.Errorf("Error retrieving JIRA issue: %v", err)
+		log.Errorf("Error retrieving JIRA issue: %w", err)
 		return jira.Issue{}, getErrorBody(j.config, res)
 	}
 	issue, ok := i.(*jira.Issue)

--- a/lib/clients/oauth.go
+++ b/lib/clients/oauth.go
@@ -6,7 +6,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -50,7 +50,7 @@ func oauthConfig(config cfg.Config) (oauth1.Config, error) {
 		return oauth1.Config{}, fmt.Errorf("unable to open private key file for reading: %w", err)
 	}
 
-	pvtKey, err := ioutil.ReadAll(pvtKeyFile)
+	pvtKey, err := io.ReadAll(pvtKeyFile)
 	if err != nil {
 		return oauth1.Config{}, fmt.Errorf("unable to read contents of private key file: %w", err)
 	}

--- a/lib/clients/oauth.go
+++ b/lib/clients/oauth.go
@@ -57,10 +57,10 @@ func oauthConfig(config cfg.Config) (oauth1.Config, error) {
 
 	keyDERBlock, _ := pem.Decode(pvtKey)
 	if keyDERBlock == nil {
-		return oauth1.Config{}, errors.New("unable to decode private key PEM block")
+		return oauth1.Config{}, errPEMDecode
 	}
 	if keyDERBlock.Type != "PRIVATE KEY" && !strings.HasSuffix(keyDERBlock.Type, " PRIVATE KEY") {
-		return oauth1.Config{}, fmt.Errorf("unexpected private key DER block type: %s", keyDERBlock.Type)
+		return oauth1.Config{}, errUnexpectedKeyType(keyDERBlock.Type)
 	}
 
 	key, err := x509.ParsePKCS1PrivateKey(keyDERBlock.Bytes)
@@ -133,4 +133,12 @@ func jiraTokenFromWeb(config oauth1.Config) (*oauth1.Token, error) {
 	}
 
 	return oauth1.NewToken(accessToken, accessSecret), nil
+}
+
+// Errors
+
+var errPEMDecode = errors.New("unable to decode private key PEM block")
+
+func errUnexpectedKeyType(keyType string) error {
+	return fmt.Errorf("unexpected private key DER block type: %s", keyType) //nolint:goerr113
 }

--- a/lib/clients/oauth.go
+++ b/lib/clients/oauth.go
@@ -47,12 +47,12 @@ func oauthConfig(config cfg.Config) (oauth1.Config, error) {
 
 	pvtKeyFile, err := os.Open(pvtKeyPath)
 	if err != nil {
-		return oauth1.Config{}, fmt.Errorf("unable to open private key file for reading: %v", err)
+		return oauth1.Config{}, fmt.Errorf("unable to open private key file for reading: %w", err)
 	}
 
 	pvtKey, err := ioutil.ReadAll(pvtKeyFile)
 	if err != nil {
-		return oauth1.Config{}, fmt.Errorf("unable to read contents of private key file: %v", err)
+		return oauth1.Config{}, fmt.Errorf("unable to read contents of private key file: %w", err)
 	}
 
 	keyDERBlock, _ := pem.Decode(pvtKey)
@@ -65,7 +65,7 @@ func oauthConfig(config cfg.Config) (oauth1.Config, error) {
 
 	key, err := x509.ParsePKCS1PrivateKey(keyDERBlock.Bytes)
 	if err != nil {
-		return oauth1.Config{}, fmt.Errorf("unable to parse PKCS1 private key: %v", err)
+		return oauth1.Config{}, fmt.Errorf("unable to parse PKCS1 private key: %w", err)
 	}
 
 	uri := config.GetConfigString("jira-uri")
@@ -109,12 +109,12 @@ func jiraTokenFromConfig(config cfg.Config) (*oauth1.Token, bool) {
 func jiraTokenFromWeb(config oauth1.Config) (*oauth1.Token, error) {
 	requestToken, requestSecret, err := config.RequestToken()
 	if err != nil {
-		return nil, fmt.Errorf("unable to get request token: %v", err)
+		return nil, fmt.Errorf("unable to get request token: %w", err)
 	}
 
 	authURL, err := config.AuthorizationURL(requestToken)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get authorize URL: %v", err)
+		return nil, fmt.Errorf("unable to get authorize URL: %w", err)
 	}
 
 	fmt.Printf("Please go to the following URL in your browser:\n%v\n\n", authURL.String())
@@ -124,12 +124,12 @@ func jiraTokenFromWeb(config oauth1.Config) (*oauth1.Token, error) {
 	_, err = fmt.Scan(&code)
 	fmt.Println()
 	if err != nil {
-		return nil, fmt.Errorf("unable to read auth code: %v", err)
+		return nil, fmt.Errorf("unable to read auth code: %w", err)
 	}
 
 	accessToken, accessSecret, err := config.AccessToken(requestToken, requestSecret, code)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get access token: %v", err)
+		return nil, fmt.Errorf("unable to get access token: %w", err)
 	}
 
 	return oauth1.NewToken(accessToken, accessSecret), nil

--- a/lib/comments.go
+++ b/lib/comments.go
@@ -57,14 +57,22 @@ func CompareComments(config cfg.Config, ghIssue github.Issue, jIssue jira.Issue,
 			}
 			// matches[0] is the whole string, matches[1] is the ID
 			matches := jCommentIDRegex.FindStringSubmatch(jComment.Body)
-			intID, _ := strconv.Atoi(matches[1])
+			intID, err := strconv.Atoi(matches[1])
+			if err != nil {
+				return err
+			}
+
 			id := int64(intID)
 			if *ghComment.ID != id {
 				continue
 			}
 			found = true
 
-			UpdateComment(config, *ghComment, jComment, jIssue, ghClient, jClient)
+			err = UpdateComment(config, *ghComment, jComment, jIssue, ghClient, jClient)
+			if err != nil {
+				return err
+			}
+
 			break
 		}
 		if found {

--- a/lib/comments.go
+++ b/lib/comments.go
@@ -57,8 +57,8 @@ func CompareComments(config cfg.Config, ghIssue github.Issue, jIssue jira.Issue,
 			}
 			// matches[0] is the whole string, matches[1] is the ID
 			matches := jCommentIDRegex.FindStringSubmatch(jComment.Body)
-			intId, _ := strconv.Atoi(matches[1])
-			id := int64(intId)
+			intID, _ := strconv.Atoi(matches[1])
+			id := int64(intID)
 			if *ghComment.ID != id {
 				continue
 			}

--- a/lib/comments.go
+++ b/lib/comments.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"fmt"
 	"regexp"
 	"strconv"
 
@@ -34,7 +35,7 @@ func CompareComments(config cfg.Config, ghIssue github.Issue, jIssue jira.Issue,
 
 	ghComments, err := ghClient.ListComments(ghIssue)
 	if err != nil {
-		return err
+		return fmt.Errorf("listing GitHub comments: %w", err)
 	}
 
 	var jComments []jira.Comment
@@ -59,7 +60,7 @@ func CompareComments(config cfg.Config, ghIssue github.Issue, jIssue jira.Issue,
 			matches := jCommentIDRegex.FindStringSubmatch(jComment.Body)
 			intID, err := strconv.Atoi(matches[1])
 			if err != nil {
-				return err
+				return fmt.Errorf("converting comment ID to int: %w", err)
 			}
 
 			id := int64(intID)
@@ -81,7 +82,7 @@ func CompareComments(config cfg.Config, ghIssue github.Issue, jIssue jira.Issue,
 
 		comment, err := jClient.CreateComment(jIssue, *ghComment, ghClient)
 		if err != nil {
-			return err
+			return fmt.Errorf("creating Jira comment: %w", err)
 		}
 
 		log.Debugf("Created JIRA comment %s.", comment.ID)
@@ -106,7 +107,7 @@ func UpdateComment(config cfg.Config, ghComment github.IssueComment, jComment ji
 
 	comment, err := jClient.UpdateComment(jIssue, jComment.ID, ghComment, ghClient)
 	if err != nil {
-		return err
+		return fmt.Errorf("updating Jira comment: %w", err)
 	}
 
 	log.Debug("Updated JIRA comment %s.", comment.ID)

--- a/lib/comments_test.go
+++ b/lib/comments_test.go
@@ -3,7 +3,7 @@ package lib
 import "testing"
 
 func TestJiraCommentRegex(t *testing.T) {
-	var fields = jCommentRegex.FindStringSubmatch(`Comment [(ID 484163403)|https://github.com] from GitHub user [bilbo-baggins|https://github.com/bilbo-baggins] (Bilbo Baggins) at 16:27 PM, April 17 2019:
+	fields := jCommentRegex.FindStringSubmatch(`Comment [(ID 484163403)|https://github.com] from GitHub user [bilbo-baggins|https://github.com/bilbo-baggins] (Bilbo Baggins) at 16:27 PM, April 17 2019:
 
 Bla blibidy bloo bla`)
 

--- a/lib/issues.go
+++ b/lib/issues.go
@@ -49,7 +49,10 @@ func CompareIssues(config cfg.Config, ghClient clients.GitHubClient, jiraClient 
 	for _, ghIssue := range ghIssues {
 		found := false
 		for _, jIssue := range jiraIssues {
-			id, _ := jIssue.Fields.Unknowns.Int(config.GetFieldKey(cfg.GitHubID))
+			id, err := jIssue.Fields.Unknowns.Int(config.GetFieldKey(cfg.GitHubID))
+			if err != nil {
+				return err
+			}
 			if *ghIssue.ID == id {
 				found = true
 				if err := UpdateIssue(config, ghIssue, jIssue, ghClient, jiraClient); err != nil {

--- a/lib/issues.go
+++ b/lib/issues.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -25,7 +26,7 @@ func CompareIssues(config cfg.Config, ghClient clients.GitHubClient, jiraClient 
 
 	ghIssues, err := ghClient.ListIssues()
 	if err != nil {
-		return err
+		return fmt.Errorf("listing GitHub issues: %w", err)
 	}
 
 	if len(ghIssues) == 0 {
@@ -41,7 +42,7 @@ func CompareIssues(config cfg.Config, ghClient clients.GitHubClient, jiraClient 
 
 	jiraIssues, err := jiraClient.ListIssues(ids)
 	if err != nil {
-		return err
+		return fmt.Errorf("listing Jira issues: %w", err)
 	}
 
 	log.Debug("Collected all JIRA issues")
@@ -51,7 +52,7 @@ func CompareIssues(config cfg.Config, ghClient clients.GitHubClient, jiraClient 
 		for _, jIssue := range jiraIssues {
 			id, err := jIssue.Fields.Unknowns.Int(config.GetFieldKey(cfg.GitHubID))
 			if err != nil {
-				return err
+				return fmt.Errorf("retrieving field key from GitHub ID: %w", err)
 			}
 			if *ghIssue.ID == id {
 				found = true
@@ -149,7 +150,7 @@ func UpdateIssue(config cfg.Config, ghIssue github.Issue, jIssue jira.Issue, ghC
 		var err error
 		issue, err = jClient.UpdateIssue(issue)
 		if err != nil {
-			return err
+			return fmt.Errorf("updating Jira issue: %w", err)
 		}
 
 		log.Debugf("Successfully updated JIRA issue %s!", jIssue.Key)
@@ -159,8 +160,7 @@ func UpdateIssue(config cfg.Config, ghIssue github.Issue, jIssue jira.Issue, ghC
 
 	issue, err := jClient.GetIssue(jIssue.Key)
 	if err != nil {
-		log.Debugf("Failed to retrieve JIRA issue %s!", jIssue.Key)
-		return err
+		return fmt.Errorf("getting Jira issue %s: %w", jIssue.Key, err)
 	}
 
 	if err := CompareComments(config, ghIssue, issue, ghClient, jClient); err != nil {
@@ -206,12 +206,12 @@ func CreateIssue(config cfg.Config, issue github.Issue, ghClient clients.GitHubC
 
 	jIssue, err := jClient.CreateIssue(jIssue)
 	if err != nil {
-		return err
+		return fmt.Errorf("creating Jira issue: %w", err)
 	}
 
 	jIssue, err = jClient.GetIssue(jIssue.Key)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting Jira issue %s: %w", jIssue.Key, err)
 	}
 
 	log.Debugf("Created JIRA issue %s!", jIssue.Key)

--- a/lib/issues.go
+++ b/lib/issues.go
@@ -11,7 +11,7 @@ import (
 	"github.com/uwu-tools/gh-jira-issue-sync/lib/clients"
 )
 
-// dateFormat is the format used for the Last IS Update field
+// dateFormat is the format used for the Last IS Update field.
 const dateFormat = "2006-01-02T15:04:05.0-0700"
 
 // CompareIssues gets the list of GitHub issues updated since the `since` date,

--- a/lib/issues.go
+++ b/lib/issues.go
@@ -35,8 +35,8 @@ func CompareIssues(config cfg.Config, ghClient clients.GitHubClient, jiraClient 
 
 	ids := make([]int, len(ghIssues))
 	for i, v := range ghIssues {
-		ghId := v.GetID()
-		ids[i] = int(ghId)
+		ghID := v.GetID()
+		ids[i] = int(ghID)
 	}
 
 	jiraIssues, err := jiraClient.ListIssues(ids)
@@ -50,7 +50,7 @@ func CompareIssues(config cfg.Config, ghClient clients.GitHubClient, jiraClient 
 		found := false
 		for _, jIssue := range jiraIssues {
 			id, _ := jIssue.Fields.Unknowns.Int(config.GetFieldKey(cfg.GitHubID))
-			if int64(*ghIssue.ID) == id {
+			if *ghIssue.ID == id {
 				found = true
 				if err := UpdateIssue(config, ghIssue, jIssue, ghClient, jiraClient); err != nil {
 					log.Errorf("Error updating issue %s. Error: %v", jIssue.Key, err)


### PR DESCRIPTION
- lint: Add golangci-lint configuration file
- Enable linting
- cmd/version: Fix spacing in license header
- lint(generated): Run golangci-lint run --fix
- Initial lint fixes
- lint(errcheck): Fix warnings
- lint: Drop deprecated linters (deadcode,varcheck)
- lint: Re-enable commented out linters
- lint(wrapcheck): Fix warnings
- lint(goerr113): Fix warnings

Signed-off-by: Stephen Augustus <foo@auggie.dev>

