### PR TITLE
Dockerfile: Pin alpine:3.17 image by digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.17@sha256:8914eb54f968791faf6a8638949e480fef81e697984fba772b3976835194c6d4
 
 WORKDIR /opt/gh-jira-issue-sync
 


### PR DESCRIPTION
Clears pinned dependencies [alert](https://github.com/uwu-tools/gh-jira-issue-sync/security/code-scanning/10).

```console
❯ crane digest alpine:3.17
sha256:8914eb54f968791faf6a8638949e480fef81e697984fba772b3976835194c6d4
```

Signed-off-by: Stephen Augustus <foo@auggie.dev>