### PR TITLE
jira: Simplify/correct basic auth logic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,7 +46,7 @@ linters:
     - makezero
     - misspell
     - nakedret
-    #- nestif
+    - nestif
     - predeclared
     #- staticcheck
     - stylecheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,7 +39,7 @@ linters:
     - gomodguard
     - goprintffuncname
     - gosec
-    #- gosimple
+    - gosimple
     #- govet
     #- ineffassign
     #- lll

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,7 @@ linters:
     - nakedret
     - nestif
     - predeclared
-    #- staticcheck
+    - staticcheck
     - stylecheck
     - thelper
     - typecheck

--- a/comments/comments.go
+++ b/comments/comments.go
@@ -32,12 +32,14 @@ import (
 // jCommentRegex matches a generated JIRA comment. It has matching groups to retrieve the
 // GitHub Comment ID (\1), the GitHub username (\2), the GitHub real name (\3, if it exists),
 // the time the comment was posted (\3 or \4), and the body of the comment (\4 or \5).
-var jCommentRegex = regexp.MustCompile("^Comment \\[\\(ID (\\d+)\\)\\|.*?] from GitHub user \\[(.+)\\|.*?] \\((.+)\\) at (.+):\\n\\n(.+)$")
+var jCommentRegex = regexp.MustCompile(
+	`^Comment \[\(ID (\d+)\)\|.*?] from GitHub user \[(.+)\|.*?] \((.+)\) at (.+):\n\n(.+)$`,
+)
 
 // jCommentIDRegex just matches the beginning of a generated JIRA comment. It's a smaller,
 // simpler, and more efficient regex, to quickly filter only generated comments and retrieve
 // just their GitHub ID for matching.
-var jCommentIDRegex = regexp.MustCompile("^Comment \\[\\(ID (\\d+)\\)\\|")
+var jCommentIDRegex = regexp.MustCompile(`^Comment \[\(ID (\d+)\)\|`)
 
 // Compare takes a GitHub issue, and retrieves all of its comments. It then
 // matches each one to a comment in `existing`. If it finds a match, it calls

--- a/config/config.go
+++ b/config/config.go
@@ -364,7 +364,7 @@ func (c *Config) validateConfig() error {
 
 	c.basicAuth = (c.cmdConfig.GetString("jira-user") != "") && (c.cmdConfig.GetString("jira-pass") != "")
 
-	if c.basicAuth {
+	if c.basicAuth { //nolint:nestif // TODO(lint)
 		c.log.Debug("Using HTTP Basic Authentication")
 
 		jUser := c.cmdConfig.GetString("jira-user")
@@ -506,15 +506,20 @@ func (c Config) getFieldIDs(client jira.Client) (fields, error) {
 	// TODO(config): Use constants for custom field names
 	if fieldIDs.githubID == "" {
 		return fieldIDs, errCustomFieldIDNotFound("GitHub ID")
-	} else if fieldIDs.githubNumber == "" {
+	}
+	if fieldIDs.githubNumber == "" {
 		return fieldIDs, errCustomFieldIDNotFound("GitHub Number")
-	} else if fieldIDs.githubLabels == "" {
+	}
+	if fieldIDs.githubLabels == "" {
 		return fieldIDs, errCustomFieldIDNotFound("Github Labels")
-	} else if fieldIDs.githubStatus == "" {
+	}
+	if fieldIDs.githubStatus == "" {
 		return fieldIDs, errCustomFieldIDNotFound("Github Status")
-	} else if fieldIDs.githubReporter == "" {
+	}
+	if fieldIDs.githubReporter == "" {
 		return fieldIDs, errCustomFieldIDNotFound("Github Reporter")
-	} else if fieldIDs.lastUpdate == "" {
+	}
+	if fieldIDs.lastUpdate == "" {
 		return fieldIDs, errCustomFieldIDNotFound("Last Issue-Sync Update")
 	}
 


### PR DESCRIPTION
This started off as a continuation of https://github.com/uwu-tools/gh-jira-issue-sync/pull/3, but in fixing the `staticcheck` warning, we also removed the nil pointer deference in https://github.com/uwu-tools/gh-jira-issue-sync/issues/24.

Fixes https://github.com/uwu-tools/gh-jira-issue-sync/issues/24.

- lint: Fix `gosimple` warnings
- lint: Fix `nestif` warnings
- jira: Simplify/correct basic auth logic

Signed-off-by: Stephen Augustus <foo@auggie.dev>