### PR TITLE
Issue creation/update cleanups (1/n)

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -188,7 +188,7 @@ func (g realGHClient) request(f func() (interface{}, *github.Response, error)) (
 	b := backoff.NewExponentialBackOff()
 	b.MaxElapsedTime = g.cfg.GetTimeout()
 
-	_ = backoff.RetryNotify(op, b, func(err error, duration time.Duration) {
+	_ = backoff.RetryNotify(op, b, func(err error, duration time.Duration) { //nolint:errcheck
 		// Round to a whole number of milliseconds
 		duration /= RetryBackoffRoundRatio // Convert nanoseconds to milliseconds
 		duration *= RetryBackoffRoundRatio // Convert back so it appears correct

--- a/github/github.go
+++ b/github/github.go
@@ -188,7 +188,7 @@ func (g realGHClient) request(f func() (interface{}, *github.Response, error)) (
 	b := backoff.NewExponentialBackOff()
 	b.MaxElapsedTime = g.cfg.GetTimeout()
 
-	backoffErr := backoff.RetryNotify(op, b, func(err error, duration time.Duration) {
+	_ = backoff.RetryNotify(op, b, func(err error, duration time.Duration) {
 		// Round to a whole number of milliseconds
 		duration /= RetryBackoffRoundRatio // Convert nanoseconds to milliseconds
 		duration *= RetryBackoffRoundRatio // Convert back so it appears correct
@@ -196,7 +196,7 @@ func (g realGHClient) request(f func() (interface{}, *github.Response, error)) (
 		log.Errorf("Error performing operation; retrying in %v: %v", duration, err)
 	})
 
-	return ret, res, fmt.Errorf("backoff error: %w", backoffErr)
+	return ret, res, nil
 }
 
 // New creates a GitHubClient and returns it; which

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.14.0
+	github.com/trivago/tgo v1.0.7
 	golang.org/x/oauth2 v0.3.0
 	golang.org/x/term v0.3.0
 	sigs.k8s.io/release-utils v0.7.3
@@ -34,7 +35,6 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
-	github.com/trivago/tgo v1.0.7 // indirect
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
 	golang.org/x/net v0.4.0 // indirect
 	golang.org/x/sys v0.3.0 // indirect

--- a/issues/issues.go
+++ b/issues/issues.go
@@ -63,12 +63,19 @@ func Compare(cfg config.Config, ghClient github.Client, jiraClient jira.Client) 
 		return fmt.Errorf("listing Jira issues: %w", err)
 	}
 
+	log.Debugf("Jira issues found: %v", len(jiraIssues))
 	log.Debug("Collected all JIRA issues")
 
 	for _, ghIssue := range ghIssues {
 		found := false
 		for _, jIssue := range jiraIssues {
-			id, err := jIssue.Fields.Unknowns.Int(cfg.GetFieldKey(config.GitHubID))
+			fieldKey := cfg.GetFieldKey(config.GitHubID)
+			log.Debugf("GitHub ID custom field key: %s", fieldKey)
+
+			// TODO: Getting a field with Unknowns will generate a nil pointer
+			//       exception if the custom field is not defined in JIRA.
+			//       ref: https://github.com/andygrunwald/go-jira/issues/322
+			id, err := jIssue.Fields.Unknowns.Int(fieldKey)
 			if err != nil {
 				return fmt.Errorf("retrieving field key from GitHub ID: %w", err)
 			}

--- a/issues/issues.go
+++ b/issues/issues.go
@@ -89,8 +89,17 @@ func Compare(cfg config.Config, ghClient github.Client, jiraClient jira.Client) 
 				log.Infof("GitHub ID custom field (%s) does not exist", fieldKey)
 			}
 
-			if *ghIssue.ID == id {
+			ghIDStr := strconv.FormatInt(*ghIssue.ID, 10)
+			jiraID, ok := id.(string)
+			if !ok {
+				log.Debugf("GitHub ID custom field is not a string; got %T", id)
+				break
+			}
+
+			if ghIDStr == jiraID {
 				found = true
+
+				log.Infof("updating issue %s", jIssue.ID)
 				if err := UpdateIssue(cfg, ghIssue, jIssue, ghClient, jiraClient); err != nil {
 					log.Errorf("Error updating issue %s. Error: %v", jIssue.Key, err)
 				}

--- a/issues/issues.go
+++ b/issues/issues.go
@@ -18,11 +18,13 @@ package issues
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	gojira "github.com/andygrunwald/go-jira"
 	gh "github.com/google/go-github/v48/github"
+	"github.com/trivago/tgo/tcontainer"
 
 	"github.com/uwu-tools/gh-jira-issue-sync/comments"
 	"github.com/uwu-tools/gh-jira-issue-sync/config"
@@ -68,17 +70,25 @@ func Compare(cfg config.Config, ghClient github.Client, jiraClient jira.Client) 
 
 	for _, ghIssue := range ghIssues {
 		found := false
-		for _, jIssue := range jiraIssues {
-			fieldKey := cfg.GetFieldKey(config.GitHubID)
-			log.Debugf("GitHub ID custom field key: %s", fieldKey)
 
+		fieldKey := cfg.GetFieldKey(config.GitHubID)
+		log.Debugf("GitHub ID custom field key: %s", fieldKey)
+		for _, jIssue := range jiraIssues {
 			// TODO: Getting a field with Unknowns will generate a nil pointer
 			//       exception if the custom field is not defined in JIRA.
 			//       ref: https://github.com/andygrunwald/go-jira/issues/322
-			id, err := jIssue.Fields.Unknowns.Int(fieldKey)
-			if err != nil {
-				return fmt.Errorf("retrieving field key from GitHub ID: %w", err)
+			/*
+				id, err := jIssue.Fields.Unknowns.Int(fieldKey)
+				if err != nil {
+					return fmt.Errorf("retrieving field key from GitHub ID: %w", err)
+				}
+			*/
+			unknowns := jIssue.Fields.Unknowns
+			id, exists := unknowns.Value(fieldKey)
+			if !exists {
+				log.Infof("GitHub ID custom field (%s) does not exist", fieldKey)
 			}
+
 			if *ghIssue.ID == id {
 				found = true
 				if err := UpdateIssue(cfg, ghIssue, jIssue, ghClient, jiraClient); err != nil {
@@ -148,21 +158,23 @@ func UpdateIssue(cfg config.Config, ghIssue gh.Issue, jIssue gojira.Issue, ghCli
 	var issue gojira.Issue
 
 	if DidIssueChange(cfg, ghIssue, jIssue) {
-		fields := gojira.IssueFields{}
-		fields.Unknowns = map[string]interface{}{}
+		fields := *jIssue.Fields
 
 		fields.Summary = ghIssue.GetTitle()
 		fields.Description = ghIssue.GetBody()
-		fields.Unknowns[cfg.GetFieldKey(config.GitHubStatus)] = ghIssue.GetState()
-		fields.Unknowns[cfg.GetFieldKey(config.GitHubReporter)] = ghIssue.User.GetLogin()
+		fields.Unknowns.Set(cfg.GetFieldKey(config.GitHubStatus), ghIssue.GetState())
+
+		// TODO: Do we actually need to update this? It's not possible to change a
+		//       GitHub issue's reporter.
+		fields.Unknowns.Set(cfg.GetFieldKey(config.GitHubReporter), ghIssue.User.GetLogin())
 
 		labels := make([]string, len(ghIssue.Labels))
 		for i, l := range ghIssue.Labels {
 			labels[i] = l.GetName()
 		}
-		fields.Unknowns[cfg.GetFieldKey(config.GitHubLabels)] = strings.Join(labels, ",")
+		fields.Unknowns.Set(cfg.GetFieldKey(config.GitHubLabels), strings.Join(labels, ","))
 
-		fields.Unknowns[cfg.GetFieldKey(config.LastISUpdate)] = time.Now().Format(dateFormat)
+		fields.Unknowns.Set(cfg.GetFieldKey(config.LastISUpdate), time.Now().Format(dateFormat))
 
 		fields.Type = jIssue.Fields.Type
 
@@ -202,6 +214,22 @@ func CreateIssue(cfg config.Config, issue gh.Issue, ghClient github.Client, jCli
 
 	log.Debugf("Creating JIRA issue based on GitHub issue #%d", *issue.Number)
 
+	unknowns := tcontainer.NewMarshalMap()
+
+	unknowns.Set(cfg.GetFieldKey(config.GitHubID), strconv.FormatInt(issue.GetID(), 10))
+	unknowns.Set(cfg.GetFieldKey(config.GitHubNumber), strconv.Itoa(issue.GetNumber()))
+	unknowns.Set(cfg.GetFieldKey(config.GitHubStatus), issue.GetState())
+	unknowns.Set(cfg.GetFieldKey(config.GitHubReporter), issue.User.GetLogin())
+
+	// TODO: Is there a way to represent this as an array of labels in Jira?
+	strs := make([]string, len(issue.Labels))
+	for i, v := range issue.Labels {
+		strs[i] = *v.Name
+	}
+	unknowns.Set(cfg.GetFieldKey(config.GitHubLabels), strings.Join(strs, ","))
+
+	unknowns.Set(cfg.GetFieldKey(config.LastISUpdate), time.Now().Format(dateFormat))
+
 	fields := gojira.IssueFields{
 		Type: gojira.IssueType{
 			Name: "Task", // TODO: Determine issue type
@@ -209,21 +237,8 @@ func CreateIssue(cfg config.Config, issue gh.Issue, ghClient github.Client, jCli
 		Project:     cfg.GetProject(),
 		Summary:     issue.GetTitle(),
 		Description: issue.GetBody(),
-		Unknowns:    map[string]interface{}{},
+		Unknowns:    unknowns,
 	}
-
-	fields.Unknowns[cfg.GetFieldKey(config.GitHubID)] = issue.GetID()
-	fields.Unknowns[cfg.GetFieldKey(config.GitHubNumber)] = issue.GetNumber()
-	fields.Unknowns[cfg.GetFieldKey(config.GitHubStatus)] = issue.GetState()
-	fields.Unknowns[cfg.GetFieldKey(config.GitHubReporter)] = issue.User.GetLogin()
-
-	strs := make([]string, len(issue.Labels))
-	for i, v := range issue.Labels {
-		strs[i] = *v.Name
-	}
-	fields.Unknowns[cfg.GetFieldKey(config.GitHubLabels)] = strings.Join(strs, ",")
-
-	fields.Unknowns[cfg.GetFieldKey(config.LastISUpdate)] = time.Now().Format(dateFormat)
 
 	jIssue := gojira.Issue{
 		Fields: &fields,

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -145,7 +145,6 @@ func (j realJIRAClient) ListIssues(ids []int) ([]jira.Issue, error) {
 		idStrs[i] = fmt.Sprint(v)
 	}
 
-	var jql string
 	// If the list of IDs is too long, we get a 414 Request-URI Too Large, so in that case,
 	// we'll need to do the filtering ourselves.
 	// TODO: Re-enable manual filtering, if required
@@ -162,7 +161,7 @@ func (j realJIRAClient) ListIssues(ids []int) ([]jira.Issue, error) {
 			jql = fmt.Sprintf("project='%s'", j.cfg.GetProjectKey())
 		}
 	*/
-	jql = fmt.Sprintf("project='%s'", j.cfg.GetProjectKey())
+	jql := fmt.Sprintf("project='%s'", j.cfg.GetProjectKey())
 	log.Debugf("JQL query used: %s", jql)
 
 	// TODO(backoff): Considering restoring backoff logic here


### PR DESCRIPTION
- github: Fix incorrectly returning errors in backoff requests
- jira: Disable broken JQL query
- issues: Add debugs for GitHub ID custom field key nil pointer
- issues: Convert GitHub issue ID & number to allow setting in fields
- issues: Correct type comparisons to determine if issue needs update
- Fix lint warnings

Signed-off-by: Stephen Augustus <foo@auggie.dev>