### PR TITLE
Fix lint warnings (3/3)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,7 @@ linters:
     - gosimple
     #- govet
     #- ineffassign
-    #- lll
+    - lll
     - makezero
     - misspell
     - nakedret

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,7 +41,7 @@ linters:
     - gosec
     - gosimple
     #- govet
-    #- ineffassign
+    - ineffassign
     - lll
     - makezero
     - misspell

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     #- gochecknoinits
     - gocognit
     - goconst
-    #- gocritic
+    - gocritic
     - gocyclo
     - godot
     - godox

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,7 @@ linters:
     - goprintffuncname
     - gosec
     - gosimple
-    #- govet
+    - govet
     - ineffassign
     - lll
     - makezero

--- a/auth/oauth.go
+++ b/auth/oauth.go
@@ -35,7 +35,7 @@ import (
 // NewJiraHTTPClient obtains an access token (either from configuration
 // or from an OAuth handshake) and creates an HTTP client that uses the
 // token, which can be used to configure a JIRA client.
-func NewJiraHTTPClient(cfg config.Config) (*http.Client, error) {
+func NewJiraHTTPClient(cfg *config.Config) (*http.Client, error) {
 	ctx := context.Background()
 
 	oauthConfig, err := oauthConfig(cfg)
@@ -58,35 +58,35 @@ func NewJiraHTTPClient(cfg config.Config) (*http.Client, error) {
 // oauthConfig parses a private key and consumer key from the
 // configuration, and creates an OAuth configuration which can
 // be used to begin a handshake.
-func oauthConfig(cfg config.Config) (oauth1.Config, error) {
+func oauthConfig(cfg *config.Config) (*oauth1.Config, error) {
 	pvtKeyPath := cfg.GetConfigString("jira-private-key-path")
 
 	pvtKeyFile, err := os.Open(pvtKeyPath)
 	if err != nil {
-		return oauth1.Config{}, fmt.Errorf("unable to open private key file for reading: %w", err)
+		return nil, fmt.Errorf("unable to open private key file for reading: %w", err)
 	}
 
 	pvtKey, err := io.ReadAll(pvtKeyFile)
 	if err != nil {
-		return oauth1.Config{}, fmt.Errorf("unable to read contents of private key file: %w", err)
+		return nil, fmt.Errorf("unable to read contents of private key file: %w", err)
 	}
 
 	keyDERBlock, _ := pem.Decode(pvtKey)
 	if keyDERBlock == nil {
-		return oauth1.Config{}, errPEMDecode
+		return nil, errPEMDecode
 	}
 	if keyDERBlock.Type != "PRIVATE KEY" && !strings.HasSuffix(keyDERBlock.Type, " PRIVATE KEY") {
-		return oauth1.Config{}, errUnexpectedKeyType(keyDERBlock.Type)
+		return nil, errUnexpectedKeyType(keyDERBlock.Type)
 	}
 
 	key, err := x509.ParsePKCS1PrivateKey(keyDERBlock.Bytes)
 	if err != nil {
-		return oauth1.Config{}, fmt.Errorf("unable to parse PKCS1 private key: %w", err)
+		return nil, fmt.Errorf("unable to parse PKCS1 private key: %w", err)
 	}
 
 	uri := cfg.GetConfigString("jira-uri")
 
-	return oauth1.Config{
+	return &oauth1.Config{
 		ConsumerKey: cfg.GetConfigString("jira-consumer-key"),
 		CallbackURL: "oob",
 		Endpoint: oauth1.Endpoint{
@@ -103,7 +103,7 @@ func oauthConfig(cfg config.Config) (oauth1.Config, error) {
 // jiraTokenFromConfig attempts to load an OAuth access token from the
 // application configuration file. It returns the token (or null if not
 // configured) and an "ok" bool to indicate whether the token is provided.
-func jiraTokenFromConfig(cfg config.Config) (*oauth1.Token, bool) {
+func jiraTokenFromConfig(cfg *config.Config) (*oauth1.Token, bool) {
 	token := cfg.GetConfigString("jira-token")
 	if token == "" {
 		return nil, false
@@ -122,13 +122,13 @@ func jiraTokenFromConfig(cfg config.Config) (*oauth1.Token, bool) {
 
 // jiraTokenFromWeb performs an OAuth handshake, obtaining a request and
 // then an access token by authorizing with the JIRA REST API.
-func jiraTokenFromWeb(config oauth1.Config) (*oauth1.Token, error) {
-	requestToken, requestSecret, err := config.RequestToken()
+func jiraTokenFromWeb(cfg *oauth1.Config) (*oauth1.Token, error) {
+	requestToken, requestSecret, err := cfg.RequestToken()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get request token: %w", err)
 	}
 
-	authURL, err := config.AuthorizationURL(requestToken)
+	authURL, err := cfg.AuthorizationURL(requestToken)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get authorize URL: %w", err)
 	}
@@ -143,7 +143,7 @@ func jiraTokenFromWeb(config oauth1.Config) (*oauth1.Token, error) {
 		return nil, fmt.Errorf("unable to read auth code: %w", err)
 	}
 
-	accessToken, accessSecret, err := config.AccessToken(requestToken, requestSecret, code)
+	accessToken, accessSecret, err := cfg.AccessToken(requestToken, requestSecret, code)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get access token: %w", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,7 +52,7 @@ var RootCmd = &cobra.Command{
 
 		log := cfg.GetLogger()
 
-		jiraClient, err := jira.New(&cfg)
+		jiraClient, err := jira.New(cfg)
 		if err != nil {
 			return fmt.Errorf("creating Jira client: %w", err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,18 +79,87 @@ var RootCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.PersistentFlags().String("log-level", logrus.InfoLevel.String(), "Set the global log level")
-	RootCmd.PersistentFlags().String("config", "", "Config file (default is $HOME/.issue-sync.json)")
-	RootCmd.PersistentFlags().StringP("github-token", "t", "", "Set the API Token used to access the GitHub repo")
-	RootCmd.PersistentFlags().StringP("jira-user", "u", "", "Set the JIRA username to authenticate with")
-	RootCmd.PersistentFlags().StringP("jira-pass", "p", "", "Set the JIRA password to authenticate with")
-	RootCmd.PersistentFlags().StringP("repo-name", "r", "", "Set the repository path (should be form owner/repo)")
-	RootCmd.PersistentFlags().StringP("jira-uri", "U", "", "Set the base uri of the JIRA instance")
-	RootCmd.PersistentFlags().StringP("jira-project", "P", "", "Set the key of the JIRA project")
-	RootCmd.PersistentFlags().StringP("since", "s", "1970-01-01T00:00:00+0000", "Set the day that the update should run forward from")
-	RootCmd.PersistentFlags().BoolP("dry-run", "d", false, "Print out actions to be taken, but do not execute them")
-	RootCmd.PersistentFlags().DurationP("timeout", "T", time.Minute, "Set the maximum timeout on all API calls")
-	RootCmd.PersistentFlags().Duration("period", 1*time.Hour, "How often to synchronize; set to 0 for one-shot mode")
+	// TODO(cmd): Parameterize default values
+	RootCmd.PersistentFlags().String(
+		"log-level",
+		logrus.InfoLevel.String(),
+		"Set the global log level",
+	)
+
+	RootCmd.PersistentFlags().String(
+		"config",
+		"",
+		"Config file (default is $HOME/.issue-sync.json)",
+	)
+
+	RootCmd.PersistentFlags().StringP(
+		"github-token",
+		"t",
+		"",
+		"Set the API Token used to access the GitHub repo",
+	)
+
+	RootCmd.PersistentFlags().StringP(
+		"jira-user",
+		"u",
+		"",
+		"Set the JIRA username to authenticate with",
+	)
+
+	RootCmd.PersistentFlags().StringP(
+		"jira-pass",
+		"p",
+		"",
+		"Set the JIRA password to authenticate with",
+	)
+
+	RootCmd.PersistentFlags().StringP(
+		"repo-name",
+		"r",
+		"",
+		"Set the repository path (should be form owner/repo)",
+	)
+
+	RootCmd.PersistentFlags().StringP(
+		"jira-uri",
+		"U",
+		"",
+		"Set the base uri of the JIRA instance",
+	)
+
+	RootCmd.PersistentFlags().StringP(
+		"jira-project",
+		"P",
+		"",
+		"Set the key of the JIRA project",
+	)
+
+	RootCmd.PersistentFlags().StringP(
+		"since",
+		"s",
+		"1970-01-01T00:00:00+0000",
+		"Set the day that the update should run forward from",
+	)
+
+	RootCmd.PersistentFlags().BoolP(
+		"dry-run",
+		"d",
+		false,
+		"Print out actions to be taken, but do not execute them",
+	)
+
+	RootCmd.PersistentFlags().DurationP(
+		"timeout",
+		"T",
+		time.Minute,
+		"Set the maximum timeout on all API calls",
+	)
+
+	RootCmd.PersistentFlags().Duration(
+		"period",
+		1*time.Hour,
+		"How often to synchronize; set to 0 for one-shot mode",
+	)
 
 	RootCmd.AddCommand(version.Version())
 }

--- a/comments/comments.go
+++ b/comments/comments.go
@@ -45,9 +45,9 @@ var jCommentIDRegex = regexp.MustCompile(`^Comment \[\(ID (\d+)\)\|`)
 // matches each one to a comment in `existing`. If it finds a match, it calls
 // UpdateComment; if it doesn't, it calls CreateComment.
 func Compare(
-	cfg config.Config,
-	ghIssue gh.Issue,
-	jIssue gojira.Issue,
+	cfg *config.Config,
+	ghIssue *gh.Issue,
+	jIssue *gojira.Issue,
 	ghClient github.Client,
 	jClient jira.Client,
 ) error {
@@ -63,15 +63,11 @@ func Compare(
 		return fmt.Errorf("listing GitHub comments: %w", err)
 	}
 
-	var jComments []gojira.Comment
+	var jComments []*gojira.Comment
 	if jIssue.Fields.Comments == nil {
 		log.Debugf("JIRA issue %s has no comments.", jIssue.Key)
 	} else {
-		commentPtrs := jIssue.Fields.Comments.Comments
-		jComments = make([]gojira.Comment, len(commentPtrs))
-		for i, v := range commentPtrs {
-			jComments[i] = *v
-		}
+		jComments = jIssue.Fields.Comments.Comments
 		log.Debugf("JIRA issue %s has %d comments", jIssue.Key, len(jComments))
 	}
 
@@ -94,7 +90,7 @@ func Compare(
 			}
 			found = true
 
-			err = UpdateComment(cfg, *ghComment, jComment, jIssue, ghClient, jClient)
+			err = UpdateComment(cfg, ghComment, jComment, jIssue, ghClient, jClient)
 			if err != nil {
 				return err
 			}
@@ -105,7 +101,7 @@ func Compare(
 			continue
 		}
 
-		comment, err := jClient.CreateComment(jIssue, *ghComment, ghClient)
+		comment, err := jClient.CreateComment(jIssue, ghComment, ghClient)
 		if err != nil {
 			return fmt.Errorf("creating Jira comment: %w", err)
 		}
@@ -120,10 +116,10 @@ func Compare(
 // UpdateComment compares the body of a GitHub comment with the body (minus header)
 // of the JIRA comment, and updates the JIRA comment if necessary.
 func UpdateComment(
-	cfg config.Config,
-	ghComment gh.IssueComment,
-	jComment gojira.Comment,
-	jIssue gojira.Issue,
+	cfg *config.Config,
+	ghComment *gh.IssueComment,
+	jComment *gojira.Comment,
+	jIssue *gojira.Issue,
 	ghClient github.Client,
 	jClient jira.Client,
 ) error {

--- a/comments/comments.go
+++ b/comments/comments.go
@@ -44,7 +44,13 @@ var jCommentIDRegex = regexp.MustCompile(`^Comment \[\(ID (\d+)\)\|`)
 // Compare takes a GitHub issue, and retrieves all of its comments. It then
 // matches each one to a comment in `existing`. If it finds a match, it calls
 // UpdateComment; if it doesn't, it calls CreateComment.
-func Compare(cfg config.Config, ghIssue gh.Issue, jIssue gojira.Issue, ghClient github.Client, jClient jira.Client) error {
+func Compare(
+	cfg config.Config,
+	ghIssue gh.Issue,
+	jIssue gojira.Issue,
+	ghClient github.Client,
+	jClient jira.Client,
+) error {
 	log := cfg.GetLogger()
 
 	if ghIssue.GetComments() == 0 {
@@ -113,7 +119,14 @@ func Compare(cfg config.Config, ghIssue gh.Issue, jIssue gojira.Issue, ghClient 
 
 // UpdateComment compares the body of a GitHub comment with the body (minus header)
 // of the JIRA comment, and updates the JIRA comment if necessary.
-func UpdateComment(cfg config.Config, ghComment gh.IssueComment, jComment gojira.Comment, jIssue gojira.Issue, ghClient github.Client, jClient jira.Client) error {
+func UpdateComment(
+	cfg config.Config,
+	ghComment gh.IssueComment,
+	jComment gojira.Comment,
+	jIssue gojira.Issue,
+	ghClient github.Client,
+	jClient jira.Client,
+) error {
 	log := cfg.GetLogger()
 
 	// fields[0] is the whole body, 1 is the ID, 2 is the username, 3 is the real name (or "" if none)

--- a/comments/comments.go
+++ b/comments/comments.go
@@ -138,7 +138,7 @@ func UpdateComment(
 		return fmt.Errorf("updating Jira comment: %w", err)
 	}
 
-	log.Debug("Updated JIRA comment %s.", comment.ID)
+	log.Debugf("Updated JIRA comment %s", comment.ID)
 
 	return nil
 }

--- a/comments/comments_test.go
+++ b/comments/comments_test.go
@@ -18,10 +18,13 @@ package comments
 
 import "testing"
 
-func TestJiraCommentRegex(t *testing.T) {
-	fields := jCommentRegex.FindStringSubmatch(`Comment [(ID 484163403)|https://github.com] from GitHub user [bilbo-baggins|https://github.com/bilbo-baggins] (Bilbo Baggins) at 16:27 PM, April 17 2019:
+//nolint:lll
+const testComment = `Comment [(ID 484163403)|https://github.com] from GitHub user [bilbo-baggins|https://github.com/bilbo-baggins] (Bilbo Baggins) at 16:27 PM, April 17 2019:
 
-Bla blibidy bloo bla`)
+Bla blibidy bloo bla`
+
+func TestJiraCommentRegex(t *testing.T) {
+	fields := jCommentRegex.FindStringSubmatch(testComment)
 
 	if len(fields) != 6 {
 		t.Fatalf("Regex failed to parse fields %v", fields)

--- a/config/config.go
+++ b/config/config.go
@@ -92,32 +92,32 @@ type Config struct {
 // New creates a new, immutable configuration object. This object
 // holds the Viper configuration and the logger, and is validated. The
 // JIRA configuration is not yet initialized.
-func New(cmd *cobra.Command) (Config, error) {
-	config := Config{}
+func New(cmd *cobra.Command) (*Config, error) {
+	var cfg Config
 
 	var err error
-	config.cmdFile, err = cmd.Flags().GetString("config")
+	cfg.cmdFile, err = cmd.Flags().GetString("config")
 	if err != nil {
-		config.cmdFile = ""
+		cfg.cmdFile = ""
 	}
 
-	config.cmdConfig = *newViper("issue-sync", config.cmdFile)
-	config.cmdConfig.BindPFlags(cmd.Flags()) //nolint:errcheck
+	cfg.cmdConfig = *newViper("issue-sync", cfg.cmdFile)
+	cfg.cmdConfig.BindPFlags(cmd.Flags()) //nolint:errcheck
 
-	config.cmdFile = config.cmdConfig.ConfigFileUsed()
+	cfg.cmdFile = cfg.cmdConfig.ConfigFileUsed()
 
-	config.log = *newLogger("issue-sync", config.cmdConfig.GetString("log-level"))
+	cfg.log = *newLogger("issue-sync", cfg.cmdConfig.GetString("log-level"))
 
-	if err := config.validateConfig(); err != nil {
-		return Config{}, err
+	if err := cfg.validateConfig(); err != nil {
+		return nil, err
 	}
 
-	return config, nil
+	return &cfg, nil
 }
 
 // LoadJIRAConfig loads the JIRA configuration (project key,
 // custom field IDs) from a remote JIRA server.
-func (c *Config) LoadJIRAConfig(client jira.Client) error {
+func (c *Config) LoadJIRAConfig(client *jira.Client) error {
 	// TODO(j-v2): Pull context from config
 	proj, res, err := client.Project.Get(context.Background(), c.cmdConfig.GetString("jira-project"))
 	if err != nil {
@@ -143,53 +143,53 @@ func (c *Config) LoadJIRAConfig(client jira.Client) error {
 }
 
 // GetConfigFile returns the file that Viper loaded the configuration from.
-func (c Config) GetConfigFile() string {
+func (c *Config) GetConfigFile() string {
 	return c.cmdFile
 }
 
 // GetConfigString returns a string value from the Viper configuration.
-func (c Config) GetConfigString(key string) string {
+func (c *Config) GetConfigString(key string) string {
 	return c.cmdConfig.GetString(key)
 }
 
 // IsBasicAuth is true if we're using HTTP Basic Authentication, and false if
 // we're using OAuth.
-func (c Config) IsBasicAuth() bool {
+func (c *Config) IsBasicAuth() bool {
 	return c.basicAuth
 }
 
 // GetSinceParam returns the `since` configuration parameter, parsed as a time.Time.
-func (c Config) GetSinceParam() time.Time {
+func (c *Config) GetSinceParam() time.Time {
 	return c.since
 }
 
 // GetLogger returns the configured application logger.
-func (c Config) GetLogger() logrus.Entry {
+func (c *Config) GetLogger() logrus.Entry {
 	return c.log
 }
 
 // IsDryRun returns whether the application is running in dry-run mode or not.
-func (c Config) IsDryRun() bool {
+func (c *Config) IsDryRun() bool {
 	return c.cmdConfig.GetBool("dry-run")
 }
 
 // IsDaemon returns whether the application is running as a daemon.
-func (c Config) IsDaemon() bool {
+func (c *Config) IsDaemon() bool {
 	return c.cmdConfig.GetDuration("period") != 0
 }
 
 // GetDaemonPeriod returns the period on which the tool runs if in daemon mode.
-func (c Config) GetDaemonPeriod() time.Duration {
+func (c *Config) GetDaemonPeriod() time.Duration {
 	return c.cmdConfig.GetDuration("period")
 }
 
 // GetTimeout returns the configured timeout on all API calls, parsed as a time.Duration.
-func (c Config) GetTimeout() time.Duration {
+func (c *Config) GetTimeout() time.Duration {
 	return c.cmdConfig.GetDuration("timeout")
 }
 
 // GetFieldID returns the customfield ID of a JIRA custom field.
-func (c Config) GetFieldID(key fieldKey) string {
+func (c *Config) GetFieldID(key fieldKey) string {
 	switch key {
 	case GitHubID:
 		return c.fieldIDs.githubID
@@ -209,22 +209,22 @@ func (c Config) GetFieldID(key fieldKey) string {
 }
 
 // GetFieldKey returns customfield_XXXXX, where XXXXX is the custom field ID (see GetFieldID).
-func (c Config) GetFieldKey(key fieldKey) string {
+func (c *Config) GetFieldKey(key fieldKey) string {
 	return fmt.Sprintf("customfield_%s", c.GetFieldID(key))
 }
 
 // GetProject returns the JIRA project the user has configured.
-func (c Config) GetProject() jira.Project {
+func (c *Config) GetProject() jira.Project {
 	return c.project
 }
 
 // GetProjectKey returns the JIRA key of the configured project.
-func (c Config) GetProjectKey() string {
+func (c *Config) GetProjectKey() string {
 	return c.project.Key
 }
 
 // GetRepo returns the user/org name and the repo name of the configured GitHub repository.
-func (c Config) GetRepo() (string, string) {
+func (c *Config) GetRepo() (string, string) {
 	fullName := c.cmdConfig.GetString("repo-name")
 	parts := strings.Split(fullName, "/")
 	// We check that repo-name is two parts separated by a slash in New, so this is safe
@@ -233,7 +233,7 @@ func (c Config) GetRepo() (string, string) {
 
 // SetJIRAToken adds the JIRA OAuth tokens in the Viper configuration, ensuring that they
 // are saved for future runs.
-func (c Config) SetJIRAToken(token *oauth1.Token) {
+func (c *Config) SetJIRAToken(token *oauth1.Token) {
 	c.cmdConfig.Set("jira-token", token.Token)
 	c.cmdConfig.Set("jira-secret", token.TokenSecret)
 }
@@ -470,7 +470,7 @@ type jiraField struct {
 
 // getFieldIDs requests the metadata of every issue field in the JIRA
 // project, and saves the IDs of the custom fields used by issue-sync.
-func (c Config) getFieldIDs(client jira.Client) (fields, error) {
+func (c *Config) getFieldIDs(client *jira.Client) (fields, error) {
 	c.log.Debug("Collecting field IDs.")
 	// TODO(j-v2): Pull context from config
 	req, err := client.NewRequest(context.Background(), "GET", "/rest/api/2/field", nil)

--- a/config/config.go
+++ b/config/config.go
@@ -308,10 +308,8 @@ func newViper(appName, cfgFile string) *viper.Viper {
 		v.OnConfigChange(func(e fsnotify.Event) {
 			log.WithField("file", e.Name).Info("config file changed")
 		})
-	} else {
-		if cfgFile != "" {
-			log.WithError(err).Warningf("Error reading config file: %v", cfgFile)
-		}
+	} else if cfgFile != "" {
+		log.WithError(err).Warningf("Error reading config file: %v", cfgFile)
 	}
 
 	if log.Level == logrus.DebugLevel {

--- a/config/config.go
+++ b/config/config.go
@@ -66,6 +66,8 @@ type fields struct {
 }
 
 // Config is the root configuration object the application creates.
+//
+//nolint:govet
 type Config struct {
 	// cmdFile is the file Viper is using for its configuration (default $HOME/.issue-sync.json).
 	cmdFile string
@@ -451,6 +453,8 @@ func (c *Config) validateConfig() error {
 // jiraField represents field metadata in JIRA. For an example of its
 // structure, make a request to `${jira-uri}/rest/api/2/field`.
 // TODO(jira): Check if type is already represented in go-jira and remove this definition.
+//
+//nolint:govet
 type jiraField struct {
 	ID          string   `json:"id"`
 	Key         string   `json:"key"`

--- a/github/github.go
+++ b/github/github.go
@@ -32,8 +32,8 @@ import (
 // use. It allows us to swap in other implementations, such as a dry run
 // clients, or mock clients for testing.
 type Client interface {
-	ListIssues() ([]github.Issue, error)
-	ListComments(issue github.Issue) ([]*github.IssueComment, error)
+	ListIssues() ([]*github.Issue, error)
+	ListComments(issue *github.Issue) ([]*github.IssueComment, error)
 	GetUser(login string) (github.User, error)
 	GetRateLimits() (github.RateLimits, error)
 }
@@ -47,7 +47,7 @@ type realGHClient struct {
 }
 
 // ListIssues returns the list of GitHub issues since the last run of the tool.
-func (g realGHClient) ListIssues() ([]github.Issue, error) {
+func (g *realGHClient) ListIssues() ([]*github.Issue, error) {
 	log := g.cfg.GetLogger()
 
 	ctx := context.Background()
@@ -56,7 +56,7 @@ func (g realGHClient) ListIssues() ([]github.Issue, error) {
 
 	// Set it so that it will run the loop once, and it'll be updated in the loop.
 	pages := 1
-	var issues []github.Issue
+	var issues []*github.Issue
 
 	for page := 1; page <= pages; page++ {
 		is, res, err := g.request(func() (interface{}, *github.Response, error) {
@@ -80,11 +80,11 @@ func (g realGHClient) ListIssues() ([]github.Issue, error) {
 			return nil, fmt.Errorf("get GitHub issues failed: expected []*github.Issue; got %T", is) //nolint:goerr113
 		}
 
-		var issuePage []github.Issue
+		var issuePage []*github.Issue
 		for _, v := range issuePointers {
 			// If PullRequestLinks is not nil, it's a Pull Request
 			if v.PullRequestLinks == nil {
-				issuePage = append(issuePage, *v)
+				issuePage = append(issuePage, v)
 			}
 		}
 
@@ -99,7 +99,7 @@ func (g realGHClient) ListIssues() ([]github.Issue, error) {
 
 // ListComments returns the list of all comments on a GitHub issue in
 // ascending order of creation.
-func (g realGHClient) ListComments(issue github.Issue) ([]*github.IssueComment, error) {
+func (g *realGHClient) ListComments(issue *github.Issue) ([]*github.IssueComment, error) {
 	log := g.cfg.GetLogger()
 
 	ctx := context.Background()
@@ -132,7 +132,7 @@ func (g realGHClient) ListComments(issue github.Issue) ([]*github.IssueComment, 
 }
 
 // GetUser returns a GitHub user from its login.
-func (g realGHClient) GetUser(login string) (github.User, error) {
+func (g *realGHClient) GetUser(login string) (github.User, error) {
 	log := g.cfg.GetLogger()
 
 	u, _, err := g.request(func() (interface{}, *github.Response, error) {
@@ -153,7 +153,7 @@ func (g realGHClient) GetUser(login string) (github.User, error) {
 
 // GetRateLimits returns the current rate limits on the GitHub API. This is a
 // simple and lightweight request that can also be used simply for testing the API.
-func (g realGHClient) GetRateLimits() (github.RateLimits, error) {
+func (g *realGHClient) GetRateLimits() (github.RateLimits, error) {
 	log := g.cfg.GetLogger()
 
 	ctx := context.Background()
@@ -185,7 +185,7 @@ const RetryBackoffRoundRatio = time.Millisecond / time.Nanosecond
 // returns the expected value and the GitHub API response, as well as a nil
 // error. If it continues to fail until a maximum time is reached, it returns
 // a nil result as well as the returned HTTP response and a timeout error.
-func (g realGHClient) request(f func() (interface{}, *github.Response, error)) (interface{}, *github.Response, error) {
+func (g *realGHClient) request(f func() (interface{}, *github.Response, error)) (interface{}, *github.Response, error) {
 	log := g.cfg.GetLogger()
 
 	var ret interface{}
@@ -216,9 +216,7 @@ func (g realGHClient) request(f func() (interface{}, *github.Response, error)) (
 // run. For example, a dry-run clients may be created which does
 // not make any requests that would change anything on the server,
 // but instead simply prints out the actions that it's asked to take.
-func New(cfg config.Config) (Client, error) {
-	var ret Client
-
+func New(cfg *config.Config) (Client, error) {
 	log := cfg.GetLogger()
 
 	ctx := context.Background()
@@ -229,15 +227,15 @@ func New(cfg config.Config) (Client, error) {
 
 	client := github.NewClient(tc)
 
-	ret = realGHClient{
-		cfg:    cfg,
+	ret := &realGHClient{
+		cfg:    *cfg,
 		client: *client,
 	}
 
 	// Make a request so we can check that we can connect fine.
 	_, err := ret.GetRateLimits()
 	if err != nil {
-		return realGHClient{}, fmt.Errorf("getting GitHub rate limits: %w", err)
+		return nil, fmt.Errorf("getting GitHub rate limits: %w", err)
 	}
 	log.Debug("Successfully connected to GitHub.")
 

--- a/github/github.go
+++ b/github/github.go
@@ -104,12 +104,20 @@ func (g realGHClient) ListComments(issue github.Issue) ([]*github.IssueComment, 
 
 	ctx := context.Background()
 	user, repo := g.cfg.GetRepo()
-	c, _, err := g.request(func() (interface{}, *github.Response, error) {
-		return g.client.Issues.ListComments(ctx, user, repo, issue.GetNumber(), &github.IssueListCommentsOptions{ //nolint:wrapcheck
-			Sort:      github.String("created"),
-			Direction: github.String("asc"),
-		})
-	})
+	c, _, err := g.request(
+		func() (interface{}, *github.Response, error) {
+			return g.client.Issues.ListComments( //nolint:wrapcheck
+				ctx,
+				user,
+				repo,
+				issue.GetNumber(),
+				&github.IssueListCommentsOptions{
+					Sort:      github.String("created"),
+					Direction: github.String("asc"),
+				},
+			)
+		},
+	)
 	if err != nil {
 		log.Errorf("Error retrieving GitHub comments for issue #%d. Error: %v.", issue.GetNumber(), err)
 		return nil, err
@@ -160,7 +168,11 @@ func (g realGHClient) GetRateLimits() (github.RateLimits, error) {
 	rate, ok := rl.(*github.RateLimits)
 	if !ok {
 		log.Errorf("Get GitHub rate limits did not return rate limits! Got: %v", rl)
-		return github.RateLimits{}, fmt.Errorf("get GitHub rate limits failed: expected *github.RateLimits; got %T", rl) //nolint:goerr113
+		return github.RateLimits{},
+			fmt.Errorf( //nolint:goerr113
+				"get GitHub rate limits failed: expected *github.RateLimits; got %T",
+				rl,
+			)
 	}
 
 	return *rate, nil

--- a/github/github.go
+++ b/github/github.go
@@ -42,8 +42,8 @@ type Client interface {
 // requests against the GitHub REST API. It is the canonical implementation
 // of GitHubClient.
 type realGHClient struct {
-	cfg    config.Config
-	client github.Client
+	cfg    *config.Config
+	client *github.Client
 }
 
 // ListIssues returns the list of GitHub issues since the last run of the tool.
@@ -228,8 +228,8 @@ func New(cfg *config.Config) (Client, error) {
 	client := github.NewClient(tc)
 
 	ret := &realGHClient{
-		cfg:    *cfg,
-		client: *client,
+		cfg:    cfg,
+		client: client,
 	}
 
 	// Make a request so we can check that we can connect fine.

--- a/github/github.go
+++ b/github/github.go
@@ -162,7 +162,7 @@ func (g *realGHClient) GetRateLimits() (github.RateLimits, error) {
 		return g.client.RateLimits(ctx) //nolint:wrapcheck
 	})
 	if err != nil {
-		log.Errorf("Error connecting to GitHub; check your token. Error: %w", err)
+		log.Errorf("Error connecting to GitHub; check your token. Error: %v", err)
 		return github.RateLimits{}, err
 	}
 	rate, ok := rl.(*github.RateLimits)

--- a/issues/issues.go
+++ b/issues/issues.go
@@ -193,8 +193,7 @@ func UpdateIssue(
 			ID:     jIssue.ID,
 		}
 
-		var err error
-		issue, err = jClient.UpdateIssue(issue)
+		_, err := jClient.UpdateIssue(issue)
 		if err != nil {
 			return fmt.Errorf("updating Jira issue: %w", err)
 		}

--- a/issues/issues.go
+++ b/issues/issues.go
@@ -242,7 +242,7 @@ func CreateIssue(cfg *config.Config, issue *gh.Issue, ghClient github.Client, jC
 		Type: gojira.IssueType{
 			Name: "Task", // TODO: Determine issue type
 		},
-		Project:     cfg.GetProject(),
+		Project:     *cfg.GetProject(),
 		Summary:     issue.GetTitle(),
 		Description: issue.GetBody(),
 		Unknowns:    unknowns,

--- a/issues/issues.go
+++ b/issues/issues.go
@@ -39,7 +39,7 @@ const dateFormat = "2006-01-02T15:04:05.0-0700"
 // gets the list of JIRA issues which have GitHub ID custom fields in that list,
 // then matches each one. If a JIRA issue already exists for a given GitHub issue,
 // it calls UpdateIssue; if no JIRA issue already exists, it calls CreateIssue.
-func Compare(cfg config.Config, ghClient github.Client, jiraClient jira.Client) error {
+func Compare(cfg *config.Config, ghClient github.Client, jiraClient jira.Client) error {
 	log := cfg.GetLogger()
 
 	log.Debug("Collecting issues")
@@ -73,7 +73,9 @@ func Compare(cfg config.Config, ghClient github.Client, jiraClient jira.Client) 
 
 		fieldKey := cfg.GetFieldKey(config.GitHubID)
 		log.Debugf("GitHub ID custom field key: %s", fieldKey)
-		for _, jIssue := range jiraIssues {
+		for i := range jiraIssues {
+			jIssue := jiraIssues[i]
+
 			// TODO: Getting a field with Unknowns will generate a nil pointer
 			//       exception if the custom field is not defined in JIRA.
 			//       ref: https://github.com/andygrunwald/go-jira/issues/322
@@ -94,7 +96,7 @@ func Compare(cfg config.Config, ghClient github.Client, jiraClient jira.Client) 
 				found = true
 
 				log.Infof("updating issue %s", jIssue.ID)
-				if err := UpdateIssue(cfg, ghIssue, jIssue, ghClient, jiraClient); err != nil {
+				if err := UpdateIssue(cfg, ghIssue, &jIssue, ghClient, jiraClient); err != nil {
 					log.Errorf("Error updating issue %s. Error: %v", jIssue.Key, err)
 				}
 				break
@@ -112,7 +114,7 @@ func Compare(cfg config.Config, ghClient github.Client, jiraClient jira.Client) 
 
 // DidIssueChange tests each of the relevant fields on the provided JIRA and GitHub issue
 // and returns whether or not they differ.
-func DidIssueChange(cfg config.Config, ghIssue gh.Issue, jIssue gojira.Issue) bool {
+func DidIssueChange(cfg *config.Config, ghIssue *gh.Issue, jIssue *gojira.Issue) bool {
 	log := cfg.GetLogger()
 
 	log.Debugf("Comparing GitHub issue #%d and JIRA issue %s", ghIssue.GetNumber(), jIssue.Key)
@@ -154,9 +156,9 @@ func DidIssueChange(cfg config.Config, ghIssue gh.Issue, jIssue gojira.Issue) bo
 // differ, the differing fields of the JIRA issue are updated to match the GitHub
 // issue.
 func UpdateIssue(
-	cfg config.Config,
-	ghIssue gh.Issue,
-	jIssue gojira.Issue,
+	cfg *config.Config,
+	ghIssue *gh.Issue,
+	jIssue *gojira.Issue,
 	ghClient github.Client,
 	jClient jira.Client,
 ) error {
@@ -164,10 +166,8 @@ func UpdateIssue(
 
 	log.Debugf("Updating JIRA %s with GitHub #%d", jIssue.Key, *ghIssue.Number)
 
-	var issue gojira.Issue
-
 	if DidIssueChange(cfg, ghIssue, jIssue) {
-		fields := *jIssue.Fields
+		fields := jIssue.Fields
 
 		fields.Summary = ghIssue.GetTitle()
 		fields.Description = ghIssue.GetBody()
@@ -187,8 +187,8 @@ func UpdateIssue(
 
 		fields.Type = jIssue.Fields.Type
 
-		issue = gojira.Issue{
-			Fields: &fields,
+		issue := &gojira.Issue{
+			Fields: fields,
 			Key:    jIssue.Key,
 			ID:     jIssue.ID,
 		}
@@ -203,12 +203,12 @@ func UpdateIssue(
 		log.Debugf("JIRA issue %s is already up to date!", jIssue.Key)
 	}
 
-	issue, err := jClient.GetIssue(jIssue.Key)
+	foundIssue, err := jClient.GetIssue(jIssue.Key)
 	if err != nil {
 		return fmt.Errorf("getting Jira issue %s: %w", jIssue.Key, err)
 	}
 
-	if err := comments.Compare(cfg, ghIssue, issue, ghClient, jClient); err != nil {
+	if err := comments.Compare(cfg, ghIssue, foundIssue, ghClient, jClient); err != nil {
 		return fmt.Errorf("comparing comments for issue %s: %w", jIssue.Key, err)
 	}
 
@@ -217,7 +217,7 @@ func UpdateIssue(
 
 // CreateIssue generates a JIRA issue from the various fields on the given GitHub issue, then
 // sends it to the JIRA API.
-func CreateIssue(cfg config.Config, issue gh.Issue, ghClient github.Client, jClient jira.Client) error {
+func CreateIssue(cfg *config.Config, issue *gh.Issue, ghClient github.Client, jClient jira.Client) error {
 	log := cfg.GetLogger()
 
 	log.Debugf("Creating JIRA issue based on GitHub issue #%d", *issue.Number)
@@ -238,7 +238,7 @@ func CreateIssue(cfg config.Config, issue gh.Issue, ghClient github.Client, jCli
 
 	unknowns.Set(cfg.GetFieldKey(config.LastISUpdate), time.Now().Format(dateFormat))
 
-	fields := gojira.IssueFields{
+	fields := &gojira.IssueFields{
 		Type: gojira.IssueType{
 			Name: "Task", // TODO: Determine issue type
 		},
@@ -248,23 +248,23 @@ func CreateIssue(cfg config.Config, issue gh.Issue, ghClient github.Client, jCli
 		Unknowns:    unknowns,
 	}
 
-	jIssue := gojira.Issue{
-		Fields: &fields,
+	jIssue := &gojira.Issue{
+		Fields: fields,
 	}
 
-	jIssue, err := jClient.CreateIssue(jIssue)
+	newIssue, err := jClient.CreateIssue(jIssue)
 	if err != nil {
 		return fmt.Errorf("creating Jira issue: %w", err)
 	}
 
-	jIssue, err = jClient.GetIssue(jIssue.Key)
+	foundIssue, err := jClient.GetIssue(newIssue.Key)
 	if err != nil {
-		return fmt.Errorf("getting Jira issue %s: %w", jIssue.Key, err)
+		return fmt.Errorf("getting Jira issue %s: %w", newIssue.Key, err)
 	}
 
-	log.Debugf("Created JIRA issue %s!", jIssue.Key)
+	log.Debugf("Created JIRA issue %s!", newIssue.Key)
 
-	if err := comments.Compare(cfg, issue, jIssue, ghClient, jClient); err != nil {
+	if err := comments.Compare(cfg, issue, foundIssue, ghClient, jClient); err != nil {
 		return fmt.Errorf("comparing comments for issue %s: %w", jIssue.Key, err)
 	}
 

--- a/issues/issues.go
+++ b/issues/issues.go
@@ -153,7 +153,13 @@ func DidIssueChange(cfg config.Config, ghIssue gh.Issue, jIssue gojira.Issue) bo
 // UpdateIssue compares each field of a GitHub issue to a JIRA issue; if any of them
 // differ, the differing fields of the JIRA issue are updated to match the GitHub
 // issue.
-func UpdateIssue(cfg config.Config, ghIssue gh.Issue, jIssue gojira.Issue, ghClient github.Client, jClient jira.Client) error {
+func UpdateIssue(
+	cfg config.Config,
+	ghIssue gh.Issue,
+	jIssue gojira.Issue,
+	ghClient github.Client,
+	jClient jira.Client,
+) error {
 	log := cfg.GetLogger()
 
 	log.Debugf("Updating JIRA %s with GitHub #%d", jIssue.Key, *ghIssue.Number)

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -46,7 +46,7 @@ const maxJQLIssueLength = 100
 // of the body. If an error occurs during reading, that error is
 // instead printed and returned. This function closes the body for
 // further reading.
-func getErrorBody(cfg config.Config, res *jira.Response) error {
+func getErrorBody(cfg *config.Config, res *jira.Response) error {
 	log := cfg.GetLogger()
 	defer res.Body.Close()
 	body, err := io.ReadAll(res.Body)
@@ -64,11 +64,16 @@ func getErrorBody(cfg config.Config, res *jira.Response) error {
 // or test mocking.
 type Client interface {
 	ListIssues(ids []int) ([]jira.Issue, error)
-	GetIssue(key string) (jira.Issue, error)
-	CreateIssue(issue jira.Issue) (jira.Issue, error)
-	UpdateIssue(issue jira.Issue) (jira.Issue, error)
-	CreateComment(issue jira.Issue, comment gh.IssueComment, githubClient github.Client) (jira.Comment, error)
-	UpdateComment(issue jira.Issue, id string, comment gh.IssueComment, githubClient github.Client) (jira.Comment, error)
+	GetIssue(key string) (*jira.Issue, error)
+	// TODO: Remove unnecessary return values; consider only returning error
+	CreateIssue(issue *jira.Issue) (jira.Issue, error)
+	// TODO: Remove unnecessary return values; consider only returning error
+	UpdateIssue(issue *jira.Issue) (jira.Issue, error)
+	// TODO: Remove unnecessary return values; consider only returning error
+	CreateComment(issue *jira.Issue, comment *gh.IssueComment, githubClient github.Client) (jira.Comment, error)
+	// TODO: Remove unnecessary return values; consider only returning error
+	// TODO: Re-arrange arguments
+	UpdateComment(issue *jira.Issue, id string, comment *gh.IssueComment, githubClient github.Client) (jira.Comment, error)
 }
 
 // New creates a new Client and configures it with
@@ -83,7 +88,7 @@ func New(cfg *config.Config) (Client, error) {
 	var err error
 
 	if !cfg.IsBasicAuth() {
-		oauth, err := auth.NewJiraHTTPClient(*cfg)
+		oauth, err := auth.NewJiraHTTPClient(cfg)
 		if err != nil {
 			log.Errorf("Error getting OAuth config: %+v", err)
 			return nil, fmt.Errorf("initializing Jira client: %w", err)
@@ -109,20 +114,20 @@ func New(cfg *config.Config) (Client, error) {
 
 	log.Debug("JIRA clients initialized")
 
-	err = cfg.LoadJIRAConfig(*client)
+	err = cfg.LoadJIRAConfig(client)
 	if err != nil {
 		return nil, fmt.Errorf("loading Jira configuration: %w", err)
 	}
 
 	if cfg.IsDryRun() {
-		j = dryrunJIRAClient{
-			cfg:    *cfg,
-			client: *client,
+		j = &dryrunJIRAClient{
+			cfg:    cfg,
+			client: client,
 		}
 	} else {
-		j = realJIRAClient{
-			cfg:    *cfg,
-			client: *client,
+		j = &realJIRAClient{
+			cfg:    cfg,
+			client: client,
 		}
 	}
 
@@ -133,14 +138,14 @@ func New(cfg *config.Config) (Client, error) {
 // of the requests against the JIRA REST API. It is the canonical
 // implementation of JIRAClient.
 type realJIRAClient struct {
-	cfg    config.Config
-	client jira.Client
+	cfg    *config.Config
+	client *jira.Client
 }
 
 // ListIssues returns a list of JIRA issues on the configured project which
 // have GitHub IDs in the provided list. `ids` should be a comma-separated
 // list of GitHub IDs.
-func (j realJIRAClient) ListIssues(ids []int) ([]jira.Issue, error) {
+func (j *realJIRAClient) ListIssues(ids []int) ([]jira.Issue, error) {
 	log := j.cfg.GetLogger()
 
 	idStrs := make([]string, len(ids))
@@ -199,7 +204,7 @@ func (j realJIRAClient) ListIssues(ids []int) ([]jira.Issue, error) {
 
 // GetIssue returns a single JIRA issue within the configured project
 // according to the issue key (e.g. "PROJ-13").
-func (j realJIRAClient) GetIssue(key string) (jira.Issue, error) {
+func (j *realJIRAClient) GetIssue(key string) (*jira.Issue, error) {
 	log := j.cfg.GetLogger()
 
 	i, res, err := j.request(func() (interface{}, *jira.Response, error) {
@@ -209,26 +214,26 @@ func (j realJIRAClient) GetIssue(key string) (jira.Issue, error) {
 	})
 	if err != nil {
 		log.Errorf("Error retrieving JIRA issue: %+v", err)
-		return jira.Issue{}, getErrorBody(j.cfg, res)
+		return nil, getErrorBody(j.cfg, res)
 	}
 	issue, ok := i.(*jira.Issue)
 	if !ok {
 		log.Errorf("Get JIRA issue did not return issue! Got %v", i)
-		return jira.Issue{}, fmt.Errorf("get JIRA issue failed: expected *jira.Issue; got %T", i) //nolint:goerr113
+		return nil, fmt.Errorf("get JIRA issue failed: expected *jira.Issue; got %T", i) //nolint:goerr113
 	}
 
-	return *issue, nil
+	return issue, nil
 }
 
 // CreateIssue creates a new JIRA issue according to the fields provided in
 // the provided issue object. It returns the created issue, with all the
 // fields provided (including e.g. ID and Key).
-func (j realJIRAClient) CreateIssue(issue jira.Issue) (jira.Issue, error) {
+func (j *realJIRAClient) CreateIssue(issue *jira.Issue) (jira.Issue, error) {
 	log := j.cfg.GetLogger()
 
 	i, res, err := j.request(func() (interface{}, *jira.Response, error) {
 		// TODO(j-v2): Pull context from config
-		return j.client.Issue.Create(context.Background(), &issue) //nolint:wrapcheck
+		return j.client.Issue.Create(context.Background(), issue) //nolint:wrapcheck
 	})
 	if err != nil {
 		log.Errorf("Error creating JIRA issue: %+v", err)
@@ -246,13 +251,13 @@ func (j realJIRAClient) CreateIssue(issue jira.Issue) (jira.Issue, error) {
 // UpdateIssue updates a given issue (identified by the Key field of the provided
 // issue object) with the fields on the provided issue. It returns the updated
 // issue as it exists on JIRA.
-func (j realJIRAClient) UpdateIssue(issue jira.Issue) (jira.Issue, error) {
+func (j *realJIRAClient) UpdateIssue(issue *jira.Issue) (jira.Issue, error) {
 	log := j.cfg.GetLogger()
 
 	i, res, err := j.request(func() (interface{}, *jira.Response, error) {
 		// TODO(j-v2): Pull context from config
 		// TODO(j-v2): Add query options
-		return j.client.Issue.Update(context.Background(), &issue, nil) //nolint:wrapcheck
+		return j.client.Issue.Update(context.Background(), issue, nil) //nolint:wrapcheck
 	})
 	if err != nil {
 		log.Errorf("Error updating JIRA issue %s: %v", issue.Key, err)
@@ -273,9 +278,9 @@ const maxBodyLength = 1 << 15
 
 // CreateComment adds a comment to the provided JIRA issue using the fields from
 // the provided GitHub comment. It then returns the created comment.
-func (j realJIRAClient) CreateComment(
-	issue jira.Issue,
-	comment gh.IssueComment,
+func (j *realJIRAClient) CreateComment(
+	issue *jira.Issue,
+	comment *gh.IssueComment,
 	githubClient github.Client,
 ) (jira.Comment, error) {
 	log := j.cfg.GetLogger()
@@ -324,10 +329,10 @@ func (j realJIRAClient) CreateComment(
 // UpdateComment updates a comment (identified by the `id` parameter) on a given
 // JIRA with a new body from the fields of the given GitHub comment. It returns
 // the updated comment.
-func (j realJIRAClient) UpdateComment(
-	issue jira.Issue,
+func (j *realJIRAClient) UpdateComment(
+	issue *jira.Issue,
 	id string,
-	comment gh.IssueComment,
+	comment *gh.IssueComment,
 	githubClient github.Client,
 ) (jira.Comment, error) {
 	log := j.cfg.GetLogger()
@@ -394,7 +399,7 @@ func (j realJIRAClient) UpdateComment(
 // returns the expected value and the JIRA API response, as well as a nil
 // error. If it continues to fail until a maximum time is reached, it returns
 // a nil result as well as the returned HTTP response and a timeout error.
-func (j realJIRAClient) request(f func() (interface{}, *jira.Response, error)) (interface{}, *jira.Response, error) {
+func (j *realJIRAClient) request(f func() (interface{}, *jira.Response, error)) (interface{}, *jira.Response, error) {
 	log := j.cfg.GetLogger()
 
 	var ret interface{}
@@ -425,8 +430,8 @@ func (j realJIRAClient) request(f func() (interface{}, *jira.Response, error)) (
 // unsafe requests which may modify server data, instead printing out the
 // actions it is asked to perform without making the request.
 type dryrunJIRAClient struct {
-	cfg    config.Config
-	client jira.Client
+	cfg    *config.Config
+	client *jira.Client
 }
 
 // newlineReplaceRegex is a regex to match both "\r\n" and just "\n" newline styles,
@@ -453,7 +458,7 @@ func truncate(s string, length int) string {
 // list of GitHub IDs.
 //
 // This function is identical to that in realJIRAClient.
-func (j dryrunJIRAClient) ListIssues(ids []int) ([]jira.Issue, error) {
+func (j *dryrunJIRAClient) ListIssues(ids []int) ([]jira.Issue, error) {
 	log := j.cfg.GetLogger()
 
 	idStrs := make([]string, len(ids))
@@ -511,7 +516,7 @@ func (j dryrunJIRAClient) ListIssues(ids []int) ([]jira.Issue, error) {
 // according to the issue key (e.g. "PROJ-13").
 //
 // This function is identical to that in realJIRAClient.
-func (j dryrunJIRAClient) GetIssue(key string) (jira.Issue, error) {
+func (j *dryrunJIRAClient) GetIssue(key string) (*jira.Issue, error) {
 	log := j.cfg.GetLogger()
 
 	i, res, err := j.request(func() (interface{}, *jira.Response, error) {
@@ -521,21 +526,21 @@ func (j dryrunJIRAClient) GetIssue(key string) (jira.Issue, error) {
 	})
 	if err != nil {
 		log.Errorf("Error retrieving JIRA issue: %+v", err)
-		return jira.Issue{}, getErrorBody(j.cfg, res)
+		return nil, getErrorBody(j.cfg, res)
 	}
 	issue, ok := i.(*jira.Issue)
 	if !ok {
 		log.Errorf("Get JIRA issue did not return issue! Got %v", i)
-		return jira.Issue{}, fmt.Errorf("get JIRA issue failed: expected *jira.Issue; got %T", i) //nolint:goerr113
+		return nil, fmt.Errorf("get JIRA issue failed: expected *jira.Issue; got %T", i) //nolint:goerr113
 	}
 
-	return *issue, nil
+	return issue, nil
 }
 
 // CreateIssue prints out the fields that would be set on a new issue were
 // it to be created according to the provided issue object. It returns the
 // provided issue object as-is.
-func (j dryrunJIRAClient) CreateIssue(issue jira.Issue) (jira.Issue, error) {
+func (j *dryrunJIRAClient) CreateIssue(issue *jira.Issue) (jira.Issue, error) {
 	log := j.cfg.GetLogger()
 
 	fields := issue.Fields
@@ -551,13 +556,13 @@ func (j dryrunJIRAClient) CreateIssue(issue jira.Issue) (jira.Issue, error) {
 	log.Infof("  Reporter: %s", fields.Unknowns[j.cfg.GetFieldKey(config.GitHubReporter)])
 	log.Info("")
 
-	return issue, nil
+	return *issue, nil
 }
 
 // UpdateIssue prints out the fields that would be set on a JIRA issue
 // (identified by issue.Key) were it to be updated according to the issue
 // object. It then returns the provided issue object as-is.
-func (j dryrunJIRAClient) UpdateIssue(issue jira.Issue) (jira.Issue, error) {
+func (j *dryrunJIRAClient) UpdateIssue(issue *jira.Issue) (jira.Issue, error) {
 	log := j.cfg.GetLogger()
 
 	fields := issue.Fields
@@ -576,15 +581,15 @@ func (j dryrunJIRAClient) UpdateIssue(issue jira.Issue) (jira.Issue, error) {
 	}
 	log.Info("")
 
-	return issue, nil
+	return *issue, nil
 }
 
 // CreateComment prints the body that would be set on a new comment if it were
 // to be created according to the fields of the provided GitHub comment. It then
 // returns a comment object containing the body that would be used.
-func (j dryrunJIRAClient) CreateComment(
-	issue jira.Issue,
-	comment gh.IssueComment,
+func (j *dryrunJIRAClient) CreateComment(
+	issue *jira.Issue,
+	comment *gh.IssueComment,
 	githubClient github.Client,
 ) (jira.Comment, error) {
 	log := j.cfg.GetLogger()
@@ -625,10 +630,10 @@ func (j dryrunJIRAClient) CreateComment(
 // UpdateComment prints the body that would be set on a comment were it to be
 // updated according to the provided GitHub comment. It then returns a comment
 // object containing the body that would be used.
-func (j dryrunJIRAClient) UpdateComment(
-	issue jira.Issue,
+func (j *dryrunJIRAClient) UpdateComment(
+	issue *jira.Issue,
 	id string,
-	comment gh.IssueComment,
+	comment *gh.IssueComment,
 	githubClient github.Client,
 ) (jira.Comment, error) {
 	log := j.cfg.GetLogger()
@@ -674,7 +679,7 @@ func (j dryrunJIRAClient) UpdateComment(
 // a nil result as well as the returned HTTP response and a timeout error.
 //
 // This function is identical to that in realJIRAClient.
-func (j dryrunJIRAClient) request(f func() (interface{}, *jira.Response, error)) (interface{}, *jira.Response, error) {
+func (j *dryrunJIRAClient) request(f func() (interface{}, *jira.Response, error)) (interface{}, *jira.Response, error) {
 	log := j.cfg.GetLogger()
 
 	var ret interface{}

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -273,7 +273,11 @@ const maxBodyLength = 1 << 15
 
 // CreateComment adds a comment to the provided JIRA issue using the fields from
 // the provided GitHub comment. It then returns the created comment.
-func (j realJIRAClient) CreateComment(issue jira.Issue, comment gh.IssueComment, githubClient github.Client) (jira.Comment, error) {
+func (j realJIRAClient) CreateComment(
+	issue jira.Issue,
+	comment gh.IssueComment,
+	githubClient github.Client,
+) (jira.Comment, error) {
 	log := j.cfg.GetLogger()
 
 	user, err := githubClient.GetUser(comment.User.GetLogin())
@@ -320,7 +324,12 @@ func (j realJIRAClient) CreateComment(issue jira.Issue, comment gh.IssueComment,
 // UpdateComment updates a comment (identified by the `id` parameter) on a given
 // JIRA with a new body from the fields of the given GitHub comment. It returns
 // the updated comment.
-func (j realJIRAClient) UpdateComment(issue jira.Issue, id string, comment gh.IssueComment, githubClient github.Client) (jira.Comment, error) {
+func (j realJIRAClient) UpdateComment(
+	issue jira.Issue,
+	id string,
+	comment gh.IssueComment,
+	githubClient github.Client,
+) (jira.Comment, error) {
 	log := j.cfg.GetLogger()
 
 	user, err := githubClient.GetUser(comment.User.GetLogin())
@@ -573,7 +582,11 @@ func (j dryrunJIRAClient) UpdateIssue(issue jira.Issue) (jira.Issue, error) {
 // CreateComment prints the body that would be set on a new comment if it were
 // to be created according to the fields of the provided GitHub comment. It then
 // returns a comment object containing the body that would be used.
-func (j dryrunJIRAClient) CreateComment(issue jira.Issue, comment gh.IssueComment, githubClient github.Client) (jira.Comment, error) {
+func (j dryrunJIRAClient) CreateComment(
+	issue jira.Issue,
+	comment gh.IssueComment,
+	githubClient github.Client,
+) (jira.Comment, error) {
 	log := j.cfg.GetLogger()
 
 	user, err := githubClient.GetUser(comment.User.GetLogin())
@@ -612,7 +625,12 @@ func (j dryrunJIRAClient) CreateComment(issue jira.Issue, comment gh.IssueCommen
 // UpdateComment prints the body that would be set on a comment were it to be
 // updated according to the provided GitHub comment. It then returns a comment
 // object containing the body that would be used.
-func (j dryrunJIRAClient) UpdateComment(issue jira.Issue, id string, comment gh.IssueComment, githubClient github.Client) (jira.Comment, error) {
+func (j dryrunJIRAClient) UpdateComment(
+	issue jira.Issue,
+	id string,
+	comment gh.IssueComment,
+	githubClient github.Client,
+) (jira.Comment, error) {
 	log := j.cfg.GetLogger()
 
 	user, err := githubClient.GetUser(comment.User.GetLogin())


### PR DESCRIPTION
- lint: Fix `lll` warnings
- lint: Fix `ineffassign` warnings
- lint: Fix `elseif` warnings
- lint: Fix `hugeParam` warnings
- lint: Fix remaining `gocritic` warnings
- lint: Fix `printf` warnings
- lint: Fix `govet` warnings

Signed-off-by: Stephen Augustus <foo@auggie.dev>