### PR TITLE
Correct field types and comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ appropriate project's screens:
 | --- | --- |
 | `GitHub ID` | Short text (plain text only) |
 | `GitHub Number` | Short text (plain text only) |
-| `GitHub Labels` | Short text (plain text only) |
 | `GitHub Status` | Short text (plain text only) |
 | `GitHub Reporter` | Short text (plain text only) |
+| `GitHub Labels` | Labels |
 | `Last Issue-Sync Update` | Date Time Picker |
 
 If you intend to use OAuth with JIRA, you must create an inbound

--- a/README.md
+++ b/README.md
@@ -17,12 +17,17 @@ sure you have a user account that can access the project and create
 issues on it; it's recommended that you create an account specifically
 for the issue-sync tool.
 
-Add the following custom fields to the project: `GitHub ID`, `GitHub
-Number`, `GitHub Labels`, `GitHub Status`, `GitHub Reporter`, and `Last
-Issue-Sync Update`. These fields are required and the names must match
-exactly. In addition,  `GitHub ID` and `GitHub Number` must be number
-fields, `Last Issue-Sync Update` must be a date time field, and the
-remainder must be text fields.
+The following custom fields must be configured AND associated to the
+appropriate project's screens:
+
+| Custom Field Name | Type |
+| --- | --- |
+| `GitHub ID` | Short text (plain text only) |
+| `GitHub Number` | Short text (plain text only) |
+| `GitHub Labels` | Short text (plain text only) |
+| `GitHub Status` | Short text (plain text only) |
+| `GitHub Reporter` | Short text (plain text only) |
+| `Last Issue-Sync Update` | Date Time Picker |
 
 If you intend to use OAuth with JIRA, you must create an inbound
 application connection and add a public key. Instructions can be found

--- a/jira/issue/issue.go
+++ b/jira/issue/issue.go
@@ -66,6 +66,7 @@ func Compare(cfg *config.Config, ghClient github.Client, jiraClient jira.Client)
 	log.Debugf("Jira issues found: %v", len(jiraIssues))
 	log.Debug("Collected all JIRA issues")
 
+	// TODO(compare): Consider move ID comparison logic into separate function
 	for _, ghIssue := range ghIssues {
 		found := false
 
@@ -85,13 +86,14 @@ func Compare(cfg *config.Config, ghClient github.Client, jiraClient jira.Client)
 				log.Infof("GitHub ID custom field (%s) does not exist", fieldKey)
 			}
 
-			jiraID, ok := id.(int64)
+			jiraID, ok := id.(float64)
 			if !ok {
-				log.Debugf("GitHub ID custom field is not an int64; got %T", id)
+				log.Debugf("GitHub ID custom field is not an float64; got %T", id)
 				break
 			}
 
-			if jiraID == ghID {
+			ghIDFloat64 := float64(ghID)
+			if jiraID == ghIDFloat64 {
 				found = true
 
 				log.Infof("updating issue %s", jIssue.ID)

--- a/jira/issue/issue.go
+++ b/jira/issue/issue.go
@@ -18,7 +18,6 @@ package issue
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
 	gojira "github.com/andygrunwald/go-jira/v2/cloud"
@@ -70,6 +69,8 @@ func Compare(cfg *config.Config, ghClient github.Client, jiraClient jira.Client)
 	for _, ghIssue := range ghIssues {
 		found := false
 
+		ghID := *ghIssue.ID
+
 		fieldKey := cfg.GetFieldKey(config.GitHubID)
 		log.Debugf("GitHub ID custom field key: %s", fieldKey)
 		for i := range jiraIssues {
@@ -84,14 +85,13 @@ func Compare(cfg *config.Config, ghClient github.Client, jiraClient jira.Client)
 				log.Infof("GitHub ID custom field (%s) does not exist", fieldKey)
 			}
 
-			ghIDStr := strconv.FormatInt(*ghIssue.ID, 10)
-			jiraID, ok := id.(string)
+			jiraID, ok := id.(int64)
 			if !ok {
-				log.Debugf("GitHub ID custom field is not a string; got %T", id)
+				log.Debugf("GitHub ID custom field is not an int64; got %T", id)
 				break
 			}
 
-			if ghIDStr == jiraID {
+			if jiraID == ghID {
 				found = true
 
 				log.Infof("updating issue %s", jIssue.ID)
@@ -236,8 +236,8 @@ func CreateIssue(cfg *config.Config, issue *gh.Issue, ghClient github.Client, jC
 
 	unknowns := tcontainer.NewMarshalMap()
 
-	unknowns.Set(cfg.GetFieldKey(config.GitHubID), strconv.FormatInt(issue.GetID(), 10))
-	unknowns.Set(cfg.GetFieldKey(config.GitHubNumber), strconv.Itoa(issue.GetNumber()))
+	unknowns.Set(cfg.GetFieldKey(config.GitHubID), issue.GetID())
+	unknowns.Set(cfg.GetFieldKey(config.GitHubNumber), issue.GetNumber())
 	unknowns.Set(cfg.GetFieldKey(config.GitHubStatus), issue.GetState())
 	unknowns.Set(cfg.GetFieldKey(config.GitHubReporter), issue.User.GetLogin())
 

--- a/jira/issue/issue.go
+++ b/jira/issue/issue.go
@@ -19,7 +19,6 @@ package issue
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	gojira "github.com/andygrunwald/go-jira/v2/cloud"
@@ -114,6 +113,8 @@ func Compare(cfg *config.Config, ghClient github.Client, jiraClient jira.Client)
 
 // DidIssueChange tests each of the relevant fields on the provided JIRA and GitHub issue
 // and returns whether or not they differ.
+//
+//nolint:gocognit // TODO(lint)
 func DidIssueChange(cfg *config.Config, ghIssue *gh.Issue, jIssue *gojira.Issue) bool {
 	log := cfg.GetLogger()
 
@@ -136,15 +137,29 @@ func DidIssueChange(cfg *config.Config, ghIssue *gh.Issue, jIssue *gojira.Issue)
 		anyDifferent = true
 	}
 
-	labels := make([]string, len(ghIssue.Labels))
-	for i, l := range ghIssue.Labels {
-		labels[i] = *l.Name
-	}
+	ghLabels := githubLabelsToStrSlice(ghIssue.Labels)
 
 	key = cfg.GetFieldKey(config.GitHubLabels)
-	field, err = jIssue.Fields.Unknowns.String(key)
-	if err != nil && strings.Join(labels, ",") != field {
-		anyDifferent = true
+	jiraLabels, err := jIssue.Fields.Unknowns.StringSlice(key)
+	if err != nil {
+		log.Errorf("collecting GitHub labels defined on Jira issue: %v", err)
+	}
+
+	for _, label := range ghLabels {
+		if !anyDifferent {
+			found := false
+			for i, jiraLabel := range jiraLabels {
+				if i < len(jiraLabels) && !found {
+					if label == jiraLabel {
+						found = true
+						break
+					}
+				} else {
+					anyDifferent = true
+					break
+				}
+			}
+		}
 	}
 
 	log.Debugf("Issues have any differences: %t", anyDifferent)
@@ -177,11 +192,8 @@ func UpdateIssue(
 		//       GitHub issue's reporter.
 		fields.Unknowns.Set(cfg.GetFieldKey(config.GitHubReporter), ghIssue.User.GetLogin())
 
-		labels := make([]string, len(ghIssue.Labels))
-		for i, l := range ghIssue.Labels {
-			labels[i] = l.GetName()
-		}
-		fields.Unknowns.Set(cfg.GetFieldKey(config.GitHubLabels), strings.Join(labels, ","))
+		labels := githubLabelsToStrSlice(ghIssue.Labels)
+		fields.Unknowns.Set(cfg.GetFieldKey(config.GitHubLabels), labels)
 
 		fields.Unknowns.Set(cfg.GetFieldKey(config.LastISUpdate), time.Now().Format(dateFormat))
 
@@ -229,12 +241,8 @@ func CreateIssue(cfg *config.Config, issue *gh.Issue, ghClient github.Client, jC
 	unknowns.Set(cfg.GetFieldKey(config.GitHubStatus), issue.GetState())
 	unknowns.Set(cfg.GetFieldKey(config.GitHubReporter), issue.User.GetLogin())
 
-	// TODO: Is there a way to represent this as an array of labels in Jira?
-	strs := make([]string, len(issue.Labels))
-	for i, v := range issue.Labels {
-		strs[i] = *v.Name
-	}
-	unknowns.Set(cfg.GetFieldKey(config.GitHubLabels), strings.Join(strs, ","))
+	labels := githubLabelsToStrSlice(issue.Labels)
+	unknowns.Set(cfg.GetFieldKey(config.GitHubLabels), labels)
 
 	unknowns.Set(cfg.GetFieldKey(config.LastISUpdate), time.Now().Format(dateFormat))
 
@@ -269,4 +277,14 @@ func CreateIssue(cfg *config.Config, issue *gh.Issue, ghClient github.Client, jC
 	}
 
 	return nil
+}
+
+// TODO(github): Consider github.IssueRequest.GetLabels() here.
+func githubLabelsToStrSlice(ghLabels []*gh.Label) []string {
+	labels := make([]string, len(ghLabels))
+	for i, l := range ghLabels {
+		labels[i] = l.GetName()
+	}
+
+	return labels
 }


### PR DESCRIPTION
- README: Clearly document field types and that they must be on screens
- issue: Configure `GitHub Labels` as a `Labels` custom field type
- issue: Configure `GitHub ID` and `GitHub Number` as a `Number` type
- issue: Perform ID comparison with `float64`s

Signed-off-by: Stephen Augustus <foo@auggie.dev>

Fixes https://github.com/uwu-tools/gh-jira-issue-sync/issues/45
Fixes https://github.com/uwu-tools/gh-jira-issue-sync/issues/29