### PR TITLE
issue: Don't attempt to populate fields from all existing

### DIFF
--- a/jira/issue/issue.go
+++ b/jira/issue/issue.go
@@ -189,7 +189,8 @@ func UpdateIssue(
 	log.Debugf("Updating JIRA %s with GitHub #%d", jIssue.Key, *ghIssue.Number)
 
 	if DidIssueChange(cfg, ghIssue, jIssue) {
-		fields := jIssue.Fields
+		fields := &gojira.IssueFields{}
+		fields.Unknowns = tcontainer.NewMarshalMap()
 
 		fields.Summary = ghIssue.GetTitle()
 		fields.Description = ghIssue.GetBody()


### PR DESCRIPTION
Fixes https://github.com/uwu-tools/gh-jira-issue-sync/issues/30.

A regression was introduced (in https://github.com/uwu-tools/gh-jira-issue-sync/pull/27 / https://github.com/uwu-tools/gh-jira-issue-sync/commit/4db59cf00575b731fec25a670f98777faab30b65) whereby all fields of an existing issue are sent in an update request.

As many of those fields may not be accessible from a screen or are otherwise unknown, all update requests will fail.

Signed-off-by: Stephen Augustus <foo@auggie.dev>