### PR TITLE
Update fixes continued

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/trivago/tgo v1.0.7
 	golang.org/x/oauth2 v0.3.0
 	golang.org/x/term v0.3.0
-	sigs.k8s.io/release-sdk v0.9.7
+	sigs.k8s.io/release-sdk v0.9.8-0.20230104002921-c885fdbbb791
 	sigs.k8s.io/release-utils v0.7.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -615,7 +615,7 @@ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/release-sdk v0.9.7 h1:YWZX0HxknbrxBO5XQUuXobc9GJ6Ol5kiNXRqR9+mmCk=
-sigs.k8s.io/release-sdk v0.9.7/go.mod h1:jf1OljdCZ0XncrztYOIM9vBQaCBu3dlvUC1Iasv4S9Q=
+sigs.k8s.io/release-sdk v0.9.8-0.20230104002921-c885fdbbb791 h1:SEcI/X73HoT9GNO8ABnC2U3mc3/B1HRiyOclmw5orYM=
+sigs.k8s.io/release-sdk v0.9.8-0.20230104002921-c885fdbbb791/go.mod h1:ohsBOgvFzg+cbNHaZL5EkeTVqjQb6mdISXUCdCOKNfo=
 sigs.k8s.io/release-utils v0.7.3 h1:6pS8x6c5RmdUgR9qcg1LO6hjUzuE4Yo9TGZ3DemrZdM=
 sigs.k8s.io/release-utils v0.7.3/go.mod h1:n0mVez/1PZYZaZUTJmxewxH3RJ/Lf7JUDh7TG1CASOE=

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -47,11 +47,7 @@ type realGHClient struct {
 	githubClient *gogh.Client
 }
 
-const (
-	itemsPerPage  = 100
-	sortOption    = "created"
-	sortDirection = "asc"
-)
+const itemsPerPage = 100
 
 // ListIssues returns the list of GitHub issues since the last run of the tool.
 func (g *realGHClient) ListIssues() ([]*gogh.Issue, error) {
@@ -64,17 +60,18 @@ func (g *realGHClient) ListIssues() ([]*gogh.Issue, error) {
 	// TODO(github): Should issue state be configurable?
 	issueState := github.IssueStateAll
 
-	// TODO(github): Consider if any of these options need to be exposed.
-	_ = &gogh.IssueListByRepoOptions{
-		Since:     g.cfg.GetSinceParam(),
-		State:     string(issueState),
-		Sort:      sortOption,
-		Direction: sortDirection,
-		ListOptions: gogh.ListOptions{
-			PerPage: itemsPerPage,
-		},
-	}
-
+	// TODO(github): Consider if these options need to be exposed upstream.
+	/*
+		gogh.IssueListByRepoOptions{
+			Since:     g.cfg.GetSinceParam(),
+			State:     string(issueState),
+			Sort:      "created",
+			Direction: "asc",
+			ListOptions: gogh.ListOptions{
+				PerPage: itemsPerPage,
+			},
+		}
+	*/
 	is, err := g.client.ListIssues(owner, repo, issueState)
 	if err != nil {
 		return nil, fmt.Errorf("listing GitHub issues: %w", err)

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -22,7 +22,7 @@ import (
 
 	jira "github.com/andygrunwald/go-jira/v2/cloud"
 	"github.com/cenkalti/backoff/v4"
-	"github.com/google/go-github/v48/github"
+	gogh "github.com/google/go-github/v48/github"
 	"github.com/sirupsen/logrus"
 )
 
@@ -34,12 +34,12 @@ const retryBackoffRoundRatio = time.Millisecond / time.Nanosecond
 // error. If it continues to fail until a maximum time is reached, it returns
 // a nil result as well as the returned HTTP response and a timeout error.
 func NewGitHubRequest(
-	f func() (interface{}, *github.Response, error),
+	f func() (interface{}, *gogh.Response, error),
 	log logrus.Entry, //nolint:gocritic
 	timeout time.Duration,
-) (interface{}, *github.Response, error) {
+) (interface{}, *gogh.Response, error) {
 	var ret interface{}
-	var res *github.Response
+	var res *gogh.Response
 
 	op := func() error {
 		var err error

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -22,38 +22,10 @@ import (
 
 	jira "github.com/andygrunwald/go-jira/v2/cloud"
 	"github.com/cenkalti/backoff/v4"
-	gogh "github.com/google/go-github/v48/github"
 	"github.com/sirupsen/logrus"
 )
 
 const retryBackoffRoundRatio = time.Millisecond / time.Nanosecond
-
-// NewGitHubRequest takes an API function from the GitHub library
-// and calls it with exponential backoff. If the function succeeds, it
-// returns the expected value and the GitHub API response, as well as a nil
-// error. If it continues to fail until a maximum time is reached, it returns
-// a nil result as well as the returned HTTP response and a timeout error.
-func NewGitHubRequest(
-	f func() (interface{}, *gogh.Response, error),
-	log logrus.Entry, //nolint:gocritic
-	timeout time.Duration,
-) (interface{}, *gogh.Response, error) {
-	var ret interface{}
-	var res *gogh.Response
-
-	op := func() error {
-		var err error
-		ret, res, err = f()
-		return err
-	}
-
-	backoffErr := retryNotify(op, log, timeout)
-	if backoffErr != nil {
-		return ret, res, errBackoff(backoffErr)
-	}
-
-	return ret, res, nil
-}
 
 // NewJiraRequest takes an API function from the JIRA library and calls it with
 // exponential backoff. If the function succeeds, it returns the expected value

--- a/internal/jira/comment/comment.go
+++ b/internal/jira/comment/comment.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 
 	gojira "github.com/andygrunwald/go-jira/v2/cloud"
-	gh "github.com/google/go-github/v48/github"
+	gogh "github.com/google/go-github/v48/github"
 
 	"github.com/uwu-tools/gh-jira-issue-sync/internal/config"
 	"github.com/uwu-tools/gh-jira-issue-sync/internal/github"
@@ -46,7 +46,7 @@ var jCommentIDRegex = regexp.MustCompile(`^Comment \[\(ID (\d+)\)\|`)
 // UpdateComment; if it doesn't, it calls CreateComment.
 func Compare(
 	cfg *config.Config,
-	ghIssue *gh.Issue,
+	ghIssue *gogh.Issue,
 	jIssue *gojira.Issue,
 	ghClient github.Client,
 	jClient jira.Client,
@@ -117,7 +117,7 @@ func Compare(
 // of the JIRA comment, and updates the JIRA comment if necessary.
 func UpdateComment(
 	cfg *config.Config,
-	ghComment *gh.IssueComment,
+	ghComment *gogh.IssueComment,
 	jComment *gojira.Comment,
 	jIssue *gojira.Issue,
 	ghClient github.Client,

--- a/internal/jira/issue/issue.go
+++ b/internal/jira/issue/issue.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	gojira "github.com/andygrunwald/go-jira/v2/cloud"
-	gh "github.com/google/go-github/v48/github"
+	gogh "github.com/google/go-github/v48/github"
 	"github.com/trivago/tgo/tcontainer"
 
 	"github.com/uwu-tools/gh-jira-issue-sync/internal/config"
@@ -120,7 +120,7 @@ func Compare(cfg *config.Config, ghClient github.Client, jiraClient jira.Client)
 // and returns whether or not they differ.
 //
 //nolint:gocognit // TODO(lint)
-func DidIssueChange(cfg *config.Config, ghIssue *gh.Issue, jIssue *gojira.Issue) bool {
+func DidIssueChange(cfg *config.Config, ghIssue *gogh.Issue, jIssue *gojira.Issue) bool {
 	log := cfg.GetLogger()
 
 	log.Debugf("Comparing GitHub issue #%d and JIRA issue %s", ghIssue.GetNumber(), jIssue.Key)
@@ -181,7 +181,7 @@ func DidIssueChange(cfg *config.Config, ghIssue *gh.Issue, jIssue *gojira.Issue)
 // issue.
 func UpdateIssue(
 	cfg *config.Config,
-	ghIssue *gh.Issue,
+	ghIssue *gogh.Issue,
 	jIssue *gojira.Issue,
 	ghClient github.Client,
 	jClient jira.Client,
@@ -239,7 +239,7 @@ func UpdateIssue(
 
 // CreateIssue generates a JIRA issue from the various fields on the given GitHub issue, then
 // sends it to the JIRA API.
-func CreateIssue(cfg *config.Config, issue *gh.Issue, ghClient github.Client, jClient jira.Client) error {
+func CreateIssue(cfg *config.Config, issue *gogh.Issue, ghClient github.Client, jClient jira.Client) error {
 	log := cfg.GetLogger()
 
 	log.Debugf("Creating JIRA issue based on GitHub issue #%d", *issue.Number)
@@ -297,7 +297,7 @@ func CreateIssue(cfg *config.Config, issue *gh.Issue, ghClient github.Client, jC
 // field type does not support spaces.
 //
 // TODO(github): Consider github.IssueRequest.GetLabels() here.
-func githubLabelsToStrSlice(ghLabels []*gh.Label) []string {
+func githubLabelsToStrSlice(ghLabels []*gogh.Label) []string {
 	labels := make([]string, len(ghLabels))
 	for i, l := range ghLabels {
 		jiraLabel := l.GetName()

--- a/internal/jira/jira.go
+++ b/internal/jira/jira.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	jira "github.com/andygrunwald/go-jira/v2/cloud"
-	gh "github.com/google/go-github/v48/github"
+	gogh "github.com/google/go-github/v48/github"
 	"github.com/sirupsen/logrus"
 
 	"github.com/uwu-tools/gh-jira-issue-sync/internal/config"
@@ -82,10 +82,14 @@ type Client interface {
 	// TODO: Remove unnecessary return values; consider only returning error
 	UpdateIssue(issue *jira.Issue) (jira.Issue, error)
 	// TODO: Remove unnecessary return values; consider only returning error
-	CreateComment(issue *jira.Issue, comment *gh.IssueComment, githubClient github.Client) (jira.Comment, error)
+	CreateComment(
+		issue *jira.Issue, comment *gogh.IssueComment, githubClient github.Client,
+	) (jira.Comment, error)
 	// TODO: Remove unnecessary return values; consider only returning error
 	// TODO: Re-arrange arguments
-	UpdateComment(issue *jira.Issue, id string, comment *gh.IssueComment, githubClient github.Client) (jira.Comment, error)
+	UpdateComment(
+		issue *jira.Issue, id string, comment *gogh.IssueComment, githubClient github.Client,
+	) (jira.Comment, error)
 }
 
 // New creates a new Client and configures it with
@@ -295,7 +299,7 @@ const maxBodyLength = 1 << 15
 // the provided GitHub comment. It then returns the created comment.
 func (j *realJIRAClient) CreateComment(
 	issue *jira.Issue,
-	comment *gh.IssueComment,
+	comment *gogh.IssueComment,
 	githubClient github.Client,
 ) (jira.Comment, error) {
 	log := j.cfg.GetLogger()
@@ -346,7 +350,7 @@ func (j *realJIRAClient) CreateComment(
 func (j *realJIRAClient) UpdateComment(
 	issue *jira.Issue,
 	id string,
-	comment *gh.IssueComment,
+	comment *gogh.IssueComment,
 	githubClient github.Client,
 ) (jira.Comment, error) {
 	log := j.cfg.GetLogger()
@@ -571,7 +575,7 @@ func (j *dryrunJIRAClient) UpdateIssue(issue *jira.Issue) (jira.Issue, error) {
 // returns a comment object containing the body that would be used.
 func (j *dryrunJIRAClient) CreateComment(
 	issue *jira.Issue,
-	comment *gh.IssueComment,
+	comment *gogh.IssueComment,
 	githubClient github.Client,
 ) (jira.Comment, error) {
 	log := j.cfg.GetLogger()
@@ -615,7 +619,7 @@ func (j *dryrunJIRAClient) CreateComment(
 func (j *dryrunJIRAClient) UpdateComment(
 	issue *jira.Issue,
 	id string,
-	comment *gh.IssueComment,
+	comment *gogh.IssueComment,
 	githubClient github.Client,
 ) (jira.Comment, error) {
 	log := j.cfg.GetLogger()

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -75,7 +75,7 @@ const (
 	DefaultSince      = "1970-01-01T00:00:00+0000"
 	DefaultDryRun     = false
 	DefaultPeriod     = time.Hour
-	DefaultTimeout    = time.Minute
+	DefaultTimeout    = 30 * time.Second
 )
 
 var DefaultLogLevelStr = DefaultLogLevel.String()


### PR DESCRIPTION
Part of https://github.com/uwu-tools/gh-jira-issue-sync/issues/57.

- go.mod: Update release-sdk to v0.9.8-0.20230104002921-c885fdbbb791 (ref: https://github.com/kubernetes-sigs/release-sdk/pull/148)
- github: Use `gogh` as named import for `github.com/google/go-github`
- github: Simplify `ListComments` logic
- github: Remove unnecessary `GetRateLimits` method
- github: Remove/comment out unnecessary options
- github: Cosmetic renames
- github: Drop backoff requests and clean up `GetUser`
- options: Lower default timeout for API calls to 30 seconds

Signed-off-by: Stephen Augustus <foo@auggie.dev>