### PR TITLE
Lessen dependency on `config` package (1/n)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,8 +55,6 @@ var RootCmd = &cobra.Command{
 			return fmt.Errorf("creating new config: %w", err)
 		}
 
-		log := cfg.GetLogger()
-
 		jiraClient, err := jira.New(cfg)
 		if err != nil {
 			return fmt.Errorf("creating Jira client: %w", err)
@@ -70,11 +68,13 @@ var RootCmd = &cobra.Command{
 
 		for {
 			if err := issue.Compare(cfg, ghClient, jiraClient); err != nil {
-				log.Error(err)
+				// TODO(log): Better error message
+				logrus.Error(err)
 			}
 			if !cfg.IsDryRun() {
 				if err := cfg.SaveConfig(); err != nil {
-					log.Error(err)
+					// TODO(log): Better error message
+					logrus.Error(err)
 				}
 			}
 			if !cfg.IsDaemon() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,7 +61,9 @@ var RootCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("creating Jira client: %w", err)
 		}
-		ghClient, err := github.New(cfg)
+
+		ghToken := cfg.GetConfigString(options.ConfigKeyGitHubToken)
+		ghClient, err := github.New(ghToken)
 		if err != nil {
 			return fmt.Errorf("creating GitHub client: %w", err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,7 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/term"
 
+	"github.com/uwu-tools/gh-jira-issue-sync/internal/github"
 	"github.com/uwu-tools/gh-jira-issue-sync/internal/options"
 )
 
@@ -248,10 +249,9 @@ func (c *Config) GetProjectKey() string {
 
 // GetRepo returns the user/org name and the repo name of the configured GitHub repository.
 func (c *Config) GetRepo() (string, string) {
-	fullName := c.cmdConfig.GetString(options.ConfigKeyRepoName)
-	parts := strings.Split(fullName, "/")
+	repoPath := c.cmdConfig.GetString(options.ConfigKeyRepoName)
 	// We check that repo-name is two parts separated by a slash in New, so this is safe
-	return parts[0], parts[1]
+	return github.GetRepo(repoPath)
 }
 
 // SetJIRAToken adds the JIRA OAuth tokens in the Viper configuration, ensuring that they

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,7 @@ import (
 	jira "github.com/andygrunwald/go-jira/v2/cloud"
 	"github.com/dghubble/oauth1"
 	"github.com/fsnotify/fsnotify"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/term"
@@ -84,9 +84,6 @@ type Config struct {
 	// API boundaries.
 	ctx context.Context
 
-	// log is a logger set up with the configured log level, app name, etc.
-	log logrus.Entry
-
 	// basicAuth represents whether we're using HTTP Basic authentication or OAuth.
 	basicAuth bool
 
@@ -120,11 +117,6 @@ func New(ctx context.Context, cmd *cobra.Command) (*Config, error) {
 
 	cfg.ctx = ctx
 
-	cfg.log = *newLogger(
-		options.AppName,
-		cfg.cmdConfig.GetString(options.ConfigKeyLogLevel),
-	)
-
 	if err := cfg.validateConfig(); err != nil {
 		return nil, err
 	}
@@ -140,15 +132,15 @@ func (c *Config) LoadJIRAConfig(client *jira.Client) error {
 		c.cmdConfig.GetString(options.ConfigKeyJiraProject),
 	)
 	if err != nil {
-		c.log.Errorf("error retrieving JIRA project; check key and credentials. Error: %s", err)
+		log.Errorf("error retrieving JIRA project; check key and credentials. Error: %s", err)
 		defer res.Body.Close()
 		body, err := io.ReadAll(res.Body)
 		if err != nil {
-			c.log.Errorf("error occurred trying to read error body: %s", err)
+			log.Errorf("error occurred trying to read error body: %s", err)
 			return fmt.Errorf("reading Jira project: %w", err)
 		}
 
-		c.log.Debugf("Error body: %s", body)
+		log.Debugf("Error body: %s", body)
 		return fmt.Errorf("reading error body: %s", string(body)) //nolint:goerr113
 	}
 	c.project = proj
@@ -185,11 +177,6 @@ func (c *Config) IsBasicAuth() bool {
 // GetSinceParam returns the `since` configuration parameter, parsed as a time.Time.
 func (c *Config) GetSinceParam() time.Time {
 	return c.since
-}
-
-// GetLogger returns the configured application logger.
-func (c *Config) GetLogger() logrus.Entry {
-	return c.log
 }
 
 // IsDryRun returns whether the application is running in dry-run mode or not.
@@ -314,7 +301,7 @@ func (c *Config) SaveConfig() error {
 // default configuration values. This viper object becomes
 // the single source of truth for the app configuration.
 func newViper(appName, cfgFile string) *viper.Viper {
-	log := logrus.New()
+	logger := log.New()
 	v := viper.New()
 
 	v.SetEnvPrefix(appName)
@@ -338,40 +325,11 @@ func newViper(appName, cfgFile string) *viper.Viper {
 		log.WithError(err).Warningf("Error reading config file: %v", cfgFile)
 	}
 
-	if log.Level == logrus.DebugLevel {
+	if logger.Level == log.DebugLevel {
 		v.Debug()
 	}
 
 	return v
-}
-
-// parseLogLevel is a helper function to parse the log level passed in the
-// configuration into a logrus Level, or to use the default log level set
-// above if the log level can't be parsed.
-func parseLogLevel(level string) logrus.Level {
-	if level == "" {
-		return options.DefaultLogLevel
-	}
-
-	ll, err := logrus.ParseLevel(level)
-	if err != nil {
-		fmt.Printf("Failed to parse log level, using default. Error: %v\n", err)
-		return options.DefaultLogLevel
-	}
-	return ll
-}
-
-// newLogger uses the log level provided in the configuration
-// to create a new logrus logger and set fields on it to make
-// it easy to use.
-func newLogger(app, level string) *logrus.Entry {
-	logger := logrus.New()
-	logger.Level = parseLogLevel(level)
-	logEntry := logrus.NewEntry(logger).WithFields(logrus.Fields{
-		"app": app,
-	})
-	logEntry.WithField("log-level", logger.Level).Info("log level set")
-	return logEntry
 }
 
 // validateConfig checks the values provided to all of the configuration
@@ -382,7 +340,7 @@ func newLogger(app, level string) *logrus.Entry {
 func (c *Config) validateConfig() error {
 	// Log level and config file location are validated already
 
-	c.log.Debug("Checking config variables...")
+	log.Debug("Checking config variables...")
 	token := c.cmdConfig.GetString(options.ConfigKeyGitHubToken)
 	if token == "" {
 		return errGitHubTokenRequired
@@ -392,7 +350,7 @@ func (c *Config) validateConfig() error {
 		(c.cmdConfig.GetString(options.ConfigKeyJiraPassword) != "")
 
 	if c.basicAuth { //nolint:nestif // TODO(lint)
-		c.log.Debug("Using HTTP Basic Authentication")
+		log.Debug("Using HTTP Basic Authentication")
 
 		jUser := c.cmdConfig.GetString(options.ConfigKeyJiraUser)
 		if jUser == "" {
@@ -410,7 +368,7 @@ func (c *Config) validateConfig() error {
 			c.cmdConfig.Set(options.ConfigKeyJiraPassword, string(bytePass))
 		}
 	} else {
-		c.log.Debug("Using OAuth 1.0a authentication")
+		log.Debug("Using OAuth 1.0a authentication")
 
 		token := c.cmdConfig.GetString(options.ConfigKeyJiraToken)
 		if token == "" {
@@ -470,7 +428,7 @@ func (c *Config) validateConfig() error {
 	}
 	c.since = since
 
-	c.log.Debug("All config variables are valid!")
+	log.Debug("All config variables are valid!")
 
 	return nil
 }
@@ -478,7 +436,7 @@ func (c *Config) validateConfig() error {
 // getFieldIDs requests the metadata of every issue field in the JIRA
 // project, and saves the IDs of the custom fields used by issue-sync.
 func (c *Config) getFieldIDs(client *jira.Client) (*fields, error) {
-	c.log.Debug("Collecting field IDs.")
+	log.Debug("Collecting field IDs.")
 	req, err := client.NewRequest(c.Context(), "GET", "/rest/api/2/field", nil)
 	if err != nil {
 		return nil, fmt.Errorf("getting fields: %w", err)
@@ -530,7 +488,7 @@ func (c *Config) getFieldIDs(client *jira.Client) (*fields, error) {
 		return nil, errCustomFieldIDNotFound(CustomFieldNameGitHubLastSync)
 	}
 
-	c.log.Debug("All fields have been checked.")
+	log.Debug("All fields have been checked.")
 
 	return &fieldIDs, nil
 }

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -22,7 +22,7 @@ import (
 
 	jira "github.com/andygrunwald/go-jira/v2/cloud"
 	"github.com/cenkalti/backoff/v4"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 const retryBackoffRoundRatio = time.Millisecond / time.Nanosecond
@@ -34,7 +34,6 @@ const retryBackoffRoundRatio = time.Millisecond / time.Nanosecond
 // returned HTTP response and a timeout error.
 func NewJiraRequest(
 	f func() (interface{}, *jira.Response, error),
-	log logrus.Entry, //nolint:gocritic
 	timeout time.Duration,
 ) (interface{}, *jira.Response, error) {
 	var ret interface{}
@@ -46,7 +45,7 @@ func NewJiraRequest(
 		return err
 	}
 
-	backoffErr := retryNotify(op, log, timeout)
+	backoffErr := retryNotify(op, timeout)
 	if backoffErr != nil {
 		return ret, res, errBackoff(backoffErr)
 	}
@@ -56,7 +55,6 @@ func NewJiraRequest(
 
 func retryNotify(
 	op backoff.Operation,
-	log logrus.Entry, //nolint:gocritic
 	timeout time.Duration,
 ) error {
 	b := backoff.NewExponentialBackOff()

--- a/internal/jira/issue/issue.go
+++ b/internal/jira/issue/issue.go
@@ -43,7 +43,8 @@ func Compare(cfg *config.Config, ghClient github.Client, jiraClient jira.Client)
 
 	log.Debug("Collecting issues")
 
-	ghIssues, err := ghClient.ListIssues()
+	owner, repo := cfg.GetRepo()
+	ghIssues, err := ghClient.ListIssues(owner, repo)
 	if err != nil {
 		return fmt.Errorf("listing GitHub issues: %w", err)
 	}

--- a/internal/jira/issue/issue.go
+++ b/internal/jira/issue/issue.go
@@ -23,6 +23,7 @@ import (
 
 	gojira "github.com/andygrunwald/go-jira/v2/cloud"
 	gogh "github.com/google/go-github/v48/github"
+	log "github.com/sirupsen/logrus"
 	"github.com/trivago/tgo/tcontainer"
 
 	"github.com/uwu-tools/gh-jira-issue-sync/internal/config"
@@ -39,8 +40,6 @@ const dateFormat = "2006-01-02T15:04:05.0-0700"
 // then matches each one. If a JIRA issue already exists for a given GitHub issue,
 // it calls UpdateIssue; if no JIRA issue already exists, it calls CreateIssue.
 func Compare(cfg *config.Config, ghClient github.Client, jiraClient jira.Client) error {
-	log := cfg.GetLogger()
-
 	log.Debug("Collecting issues")
 
 	owner, repo := cfg.GetRepo()
@@ -122,8 +121,6 @@ func Compare(cfg *config.Config, ghClient github.Client, jiraClient jira.Client)
 //
 //nolint:gocognit // TODO(lint)
 func DidIssueChange(cfg *config.Config, ghIssue *gogh.Issue, jIssue *gojira.Issue) bool {
-	log := cfg.GetLogger()
-
 	log.Debugf("Comparing GitHub issue #%d and JIRA issue %s", ghIssue.GetNumber(), jIssue.Key)
 
 	anyDifferent := false
@@ -187,8 +184,6 @@ func UpdateIssue(
 	ghClient github.Client,
 	jClient jira.Client,
 ) error {
-	log := cfg.GetLogger()
-
 	log.Debugf("Updating JIRA %s with GitHub #%d", jIssue.Key, *ghIssue.Number)
 
 	if DidIssueChange(cfg, ghIssue, jIssue) {
@@ -241,8 +236,6 @@ func UpdateIssue(
 // CreateIssue generates a JIRA issue from the various fields on the given GitHub issue, then
 // sends it to the JIRA API.
 func CreateIssue(cfg *config.Config, issue *gogh.Issue, ghClient github.Client, jClient jira.Client) error {
-	log := cfg.GetLogger()
-
 	log.Debugf("Creating JIRA issue based on GitHub issue #%d", *issue.Number)
 
 	unknowns := tcontainer.NewMarshalMap()


### PR DESCRIPTION
The `config` package has a few problems:

- internal packages overly depend on it
- function/method signatures are polluted
- `Config.log` conflicts with the global logger that was instantiated in https://github.com/uwu-tools/gh-jira-issue-sync/pull/42
- makes testing more difficult by requiring cobra/viper primitives to be introduced

This set of commits do the following:

- github: Remove dependency on `config` package
- config: Remove logger as logs are already globally configured

Signed-off-by: Stephen Augustus <foo@auggie.dev>