### PR TITLE
jira: Remove `dryrunJiraClient` and merge into default methods

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,7 +45,7 @@ func Execute() {
 // RootCmd represents the command itself and configures it.
 var RootCmd = &cobra.Command{
 	Use:               fmt.Sprintf("%s [options]", options.AppName),
-	Short:             "A tool to synchronize GitHub and JIRA issues",
+	Short:             "A tool to synchronize GitHub and Jira issues",
 	Long:              "Full docs coming later; see https://github.com/uwu-tools/gh-jira-issue-sync",
 	PersistentPreRunE: initLogging,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -27,9 +27,9 @@ import (
 
 const retryBackoffRoundRatio = time.Millisecond / time.Nanosecond
 
-// NewJiraRequest takes an API function from the JIRA library and calls it with
+// NewJiraRequest takes an API function from the Jira library and calls it with
 // exponential backoff. If the function succeeds, it returns the expected value
-// and the JIRA API response, as well as a nil error. If it continues to fail
+// and the Jira API response, as well as a nil error. If it continues to fail
 // until a maximum time is reached, it returns a nil result as well as the
 // returned HTTP response and a timeout error.
 func NewJiraRequest(

--- a/internal/jira/auth/auth.go
+++ b/internal/jira/auth/auth.go
@@ -35,7 +35,7 @@ import (
 
 // NewJiraHTTPClient obtains an access token (either from configuration
 // or from an OAuth handshake) and creates an HTTP client that uses the
-// token, which can be used to configure a JIRA client.
+// token, which can be used to configure a Jira client.
 func NewJiraHTTPClient(cfg *config.Config) (*http.Client, error) {
 	ctx := context.Background()
 
@@ -50,7 +50,7 @@ func NewJiraHTTPClient(cfg *config.Config) (*http.Client, error) {
 		if err != nil {
 			return nil, err
 		}
-		cfg.SetJIRAToken(tok)
+		cfg.SetJiraToken(tok)
 	}
 
 	return oauthConfig.Client(ctx, tok), nil
@@ -122,7 +122,7 @@ func jiraTokenFromConfig(cfg *config.Config) (*oauth1.Token, bool) {
 }
 
 // jiraTokenFromWeb performs an OAuth handshake, obtaining a request and
-// then an access token by authorizing with the JIRA REST API.
+// then an access token by authorizing with the Jira REST API.
 func jiraTokenFromWeb(cfg *oauth1.Config) (*oauth1.Token, error) {
 	requestToken, requestSecret, err := cfg.RequestToken()
 	if err != nil {

--- a/internal/jira/comment/comment.go
+++ b/internal/jira/comment/comment.go
@@ -30,14 +30,14 @@ import (
 	"github.com/uwu-tools/gh-jira-issue-sync/internal/jira"
 )
 
-// jCommentRegex matches a generated JIRA comment. It has matching groups to retrieve the
+// jCommentRegex matches a generated Jira comment. It has matching groups to retrieve the
 // GitHub Comment ID (\1), the GitHub username (\2), the GitHub real name (\3, if it exists),
 // the time the comment was posted (\3 or \4), and the body of the comment (\4 or \5).
 var jCommentRegex = regexp.MustCompile(
 	`^Comment \[\(ID (\d+)\)\|.*?] from GitHub user \[(.+)\|.*?] \((.+)\) at (.+):\n\n(.+)$`,
 )
 
-// jCommentIDRegex just matches the beginning of a generated JIRA comment. It's a smaller,
+// jCommentIDRegex just matches the beginning of a generated Jira comment. It's a smaller,
 // simpler, and more efficient regex, to quickly filter only generated comments and retrieve
 // just their GitHub ID for matching.
 var jCommentIDRegex = regexp.MustCompile(`^Comment \[\(ID (\d+)\)\|`)
@@ -71,10 +71,10 @@ func Compare(
 
 	var jComments []*gojira.Comment
 	if jIssue.Fields.Comments == nil {
-		log.Debugf("JIRA issue %s has no comments.", jIssue.Key)
+		log.Debugf("Jira issue %s has no comments.", jIssue.Key)
 	} else {
 		jComments = jIssue.Fields.Comments.Comments
-		log.Debugf("JIRA issue %s has %d comments", jIssue.Key, len(jComments))
+		log.Debugf("Jira issue %s has %d comments", jIssue.Key, len(jComments))
 	}
 
 	for _, ghComment := range ghComments {
@@ -112,15 +112,15 @@ func Compare(
 			return fmt.Errorf("creating Jira comment: %w", err)
 		}
 
-		log.Debugf("Created JIRA comment %s.", comment.ID)
+		log.Debugf("Created Jira comment %s.", comment.ID)
 	}
 
-	log.Debugf("Copied comments from GH issue #%d to JIRA issue %s.", *ghIssue.Number, jIssue.Key)
+	log.Debugf("Copied comments from GH issue #%d to Jira issue %s.", *ghIssue.Number, jIssue.Key)
 	return nil
 }
 
 // UpdateComment compares the body of a GitHub comment with the body (minus header)
-// of the JIRA comment, and updates the JIRA comment if necessary.
+// of the Jira comment, and updates the Jira comment if necessary.
 func UpdateComment(
 	cfg *config.Config,
 	ghComment *gogh.IssueComment,
@@ -142,7 +142,7 @@ func UpdateComment(
 		return fmt.Errorf("updating Jira comment: %w", err)
 	}
 
-	log.Debugf("Updated JIRA comment %s", comment.ID)
+	log.Debugf("Updated Jira comment %s", comment.ID)
 
 	return nil
 }

--- a/internal/jira/issue/issue.go
+++ b/internal/jira/issue/issue.go
@@ -36,9 +36,9 @@ import (
 const dateFormat = "2006-01-02T15:04:05.0-0700"
 
 // Compare gets the list of GitHub issues updated since the `since` date,
-// gets the list of JIRA issues which have GitHub ID custom fields in that list,
-// then matches each one. If a JIRA issue already exists for a given GitHub issue,
-// it calls UpdateIssue; if no JIRA issue already exists, it calls CreateIssue.
+// gets the list of Jira issues which have GitHub ID custom fields in that list,
+// then matches each one. If a Jira issue already exists for a given GitHub issue,
+// it calls UpdateIssue; if no Jira issue already exists, it calls CreateIssue.
 func Compare(cfg *config.Config, ghClient github.Client, jiraClient jira.Client) error {
 	log.Debug("Collecting issues")
 
@@ -65,7 +65,7 @@ func Compare(cfg *config.Config, ghClient github.Client, jiraClient jira.Client)
 	}
 
 	log.Debugf("Jira issues found: %v", len(jiraIssues))
-	log.Debug("Collected all JIRA issues")
+	log.Debug("Collected all Jira issues")
 
 	fieldKey := cfg.GetFieldKey(config.GitHubID)
 	log.Debugf("GitHub ID custom field key: %s", fieldKey)
@@ -81,7 +81,7 @@ func Compare(cfg *config.Config, ghClient github.Client, jiraClient jira.Client)
 
 			// TODO(fields): Getting a field with Unknowns will generate a nil
 			//               pointer exception if the custom field is not defined in
-			//               JIRA.
+			//               Jira.
 			//               ref: https://github.com/andygrunwald/go-jira/issues/322
 			unknowns := jIssue.Fields.Unknowns
 			id, exists := unknowns.Value(fieldKey)
@@ -116,12 +116,12 @@ func Compare(cfg *config.Config, ghClient github.Client, jiraClient jira.Client)
 	return nil
 }
 
-// DidIssueChange tests each of the relevant fields on the provided JIRA and GitHub issue
+// DidIssueChange tests each of the relevant fields on the provided Jira and GitHub issue
 // and returns whether or not they differ.
 //
 //nolint:gocognit // TODO(lint)
 func DidIssueChange(cfg *config.Config, ghIssue *gogh.Issue, jIssue *gojira.Issue) bool {
-	log.Debugf("Comparing GitHub issue #%d and JIRA issue %s", ghIssue.GetNumber(), jIssue.Key)
+	log.Debugf("Comparing GitHub issue #%d and Jira issue %s", ghIssue.GetNumber(), jIssue.Key)
 
 	anyDifferent := false
 
@@ -174,8 +174,8 @@ func DidIssueChange(cfg *config.Config, ghIssue *gogh.Issue, jIssue *gojira.Issu
 	return anyDifferent
 }
 
-// UpdateIssue compares each field of a GitHub issue to a JIRA issue; if any of them
-// differ, the differing fields of the JIRA issue are updated to match the GitHub
+// UpdateIssue compares each field of a GitHub issue to a Jira issue; if any of them
+// differ, the differing fields of the Jira issue are updated to match the GitHub
 // issue.
 func UpdateIssue(
 	cfg *config.Config,
@@ -184,7 +184,7 @@ func UpdateIssue(
 	ghClient github.Client,
 	jClient jira.Client,
 ) error {
-	log.Debugf("Updating JIRA %s with GitHub #%d", jIssue.Key, *ghIssue.Number)
+	log.Debugf("Updating Jira %s with GitHub #%d", jIssue.Key, *ghIssue.Number)
 
 	if DidIssueChange(cfg, ghIssue, jIssue) {
 		fields := &gojira.IssueFields{}
@@ -216,9 +216,9 @@ func UpdateIssue(
 			return fmt.Errorf("updating Jira issue: %w", err)
 		}
 
-		log.Debugf("Successfully updated JIRA issue %s!", jIssue.Key)
+		log.Debugf("Successfully updated Jira issue %s!", jIssue.Key)
 	} else {
-		log.Debugf("JIRA issue %s is already up to date!", jIssue.Key)
+		log.Debugf("Jira issue %s is already up to date!", jIssue.Key)
 	}
 
 	foundIssue, err := jClient.GetIssue(jIssue.Key)
@@ -233,10 +233,10 @@ func UpdateIssue(
 	return nil
 }
 
-// CreateIssue generates a JIRA issue from the various fields on the given GitHub issue, then
-// sends it to the JIRA API.
+// CreateIssue generates a Jira issue from the various fields on the given GitHub issue, then
+// sends it to the Jira API.
 func CreateIssue(cfg *config.Config, issue *gogh.Issue, ghClient github.Client, jClient jira.Client) error {
-	log.Debugf("Creating JIRA issue based on GitHub issue #%d", *issue.Number)
+	log.Debugf("Creating Jira issue based on GitHub issue #%d", *issue.Number)
 
 	unknowns := tcontainer.NewMarshalMap()
 
@@ -274,7 +274,7 @@ func CreateIssue(cfg *config.Config, issue *gogh.Issue, ghClient github.Client, 
 		return fmt.Errorf("getting Jira issue %s: %w", newIssue.Key, err)
 	}
 
-	log.Debugf("Created JIRA issue %s!", newIssue.Key)
+	log.Debugf("Created Jira issue %s!", newIssue.Key)
 
 	if err := comment.Compare(cfg, issue, foundIssue, ghClient, jClient); err != nil {
 		return fmt.Errorf("comparing comments for issue %s: %w", jIssue.Key, err)

--- a/internal/jira/jira.go
+++ b/internal/jira/jira.go
@@ -75,12 +75,21 @@ type Client interface {
 	) (jira.Comment, error)
 }
 
+// jiraClient is a standard Jira clients, which actually makes
+// of the requests against the Jira REST API. It is the canonical
+// implementation of JiraClient.
+type jiraClient struct {
+	cfg    *config.Config
+	client *jira.Client
+
+	dryRun bool
+}
+
 // New creates a new Client and configures it with
 // the config object provided. The type of clients created depends
 // on the configuration; currently, it creates either a standard
 // clients, or a dry-run clients.
 func New(cfg *config.Config) (Client, error) {
-	var j Client
 	var tp http.Client
 	var err error
 
@@ -114,62 +123,84 @@ func New(cfg *config.Config) (Client, error) {
 		return nil, fmt.Errorf("loading Jira configuration: %w", err)
 	}
 
-	if cfg.IsDryRun() {
-		j = &dryrunJiraClient{
-			cfg:    cfg,
-			client: client,
-		}
-	} else {
-		j = &realJiraClient{
-			cfg:    cfg,
-			client: client,
-		}
+	j := &jiraClient{
+		cfg:    cfg,
+		client: client,
+
+		// TODO(dry-run): Check logic here
+		dryRun: cfg.IsDryRun(),
 	}
 
 	return j, nil
 }
 
-// realJiraClient is a standard Jira clients, which actually makes
-// of the requests against the Jira REST API. It is the canonical
-// implementation of JiraClient.
-type realJiraClient struct {
-	cfg    *config.Config
-	client *jira.Client
-}
-
 // ListIssues returns a list of Jira issues on the configured project which
 // have GitHub IDs in the provided list. `ids` should be a comma-separated
 // list of GitHub IDs.
-func (j *realJiraClient) ListIssues(ids []int) ([]jira.Issue, error) {
+func (j *jiraClient) ListIssues(ids []int) ([]jira.Issue, error) { //nolint:gocognit // TODO(lint): gocognit
 	jql := getJQLQuery(
 		j.cfg.GetProjectKey(),
 		j.cfg.GetFieldID(config.GitHubID),
 		ids,
 	)
 
-	// TODO(backoff): Consider restoring backoff logic here
-	// TODO(j-v2): Parameterize all query options
-	searchOpts := &jira.SearchOptions{
-		MaxResults: maxIssueSearchResults,
-	}
-	jiraIssues, res, err := j.client.Issue.Search(j.cfg.Context(), jql, searchOpts)
-	if err != nil {
-		log.Errorf("Error retrieving Jira issues: %+v", err)
-		return nil, getErrorBody(res)
-	}
-
 	var issues []jira.Issue
-	if len(ids) < maxJQLIssueLength {
-		// The issues were already filtered by our JQL, so use as is
-		issues = jiraIssues
+	// TODO(dry-run): Simplify logic
+	if !j.dryRun { //nolint:nestif // TODO(lint): complex nested blocks (nestif)
+		// TODO(backoff): Consider restoring backoff logic here
+		// TODO(j-v2): Parameterize all query options
+		searchOpts := &jira.SearchOptions{
+			MaxResults: maxIssueSearchResults,
+		}
+		jiraIssues, res, err := j.client.Issue.Search(j.cfg.Context(), jql, searchOpts)
+		if err != nil {
+			log.Errorf("Error retrieving Jira issues: %+v", err)
+			return nil, getErrorBody(res)
+		}
+
+		if len(ids) < maxJQLIssueLength {
+			// The issues were already filtered by our JQL, so use as is
+			issues = jiraIssues
+		} else {
+			// Filter only issues which have a defined GitHub ID in the list of IDs
+			for _, v := range jiraIssues {
+				if id, err := v.Fields.Unknowns.Int(j.cfg.GetFieldKey(config.GitHubID)); err == nil {
+					for _, idOpt := range ids {
+						if id == int64(idOpt) {
+							issues = append(issues, v)
+							break
+						}
+					}
+				}
+			}
+		}
 	} else {
-		// Filter only issues which have a defined GitHub ID in the list of IDs
-		for _, v := range jiraIssues {
-			if id, err := v.Fields.Unknowns.Int(j.cfg.GetFieldKey(config.GitHubID)); err == nil {
-				for _, idOpt := range ids {
-					if id == int64(idOpt) {
-						issues = append(issues, v)
-						break
+		ji, res, err := j.request(func() (interface{}, *jira.Response, error) {
+			// TODO(j-v2): Add query options
+			return j.client.Issue.Search(j.cfg.Context(), jql, nil) //nolint:wrapcheck
+		})
+		if err != nil {
+			log.Errorf("Error retrieving Jira issues: %+v", err)
+			return nil, getErrorBody(res)
+		}
+		jiraIssues, ok := ji.([]jira.Issue)
+		if !ok {
+			log.Errorf("Get Jira issues did not return issues! Got: %v", ji)
+			return nil, fmt.Errorf("get Jira issues failed: expected []jira.Issue; got %T", ji) //nolint:goerr113
+		}
+
+		if len(ids) < maxJQLIssueLength {
+			// The issues were already filtered by our JQL, so use as is
+			issues = jiraIssues
+		} else {
+			// Filter only issues which have a defined GitHub ID in the list of IDs
+			for _, v := range jiraIssues {
+				if id, err := v.Fields.Unknowns.Int(j.cfg.GetFieldKey(config.GitHubID)); err == nil {
+					for _, idOpt := range ids {
+						if id == int64(idOpt) {
+							issues = append(issues, v)
+							break
+						}
 					}
 				}
 			}
@@ -181,7 +212,7 @@ func (j *realJiraClient) ListIssues(ids []int) ([]jira.Issue, error) {
 
 // GetIssue returns a single Jira issue within the configured project
 // according to the issue key (e.g. "PROJ-13").
-func (j *realJiraClient) GetIssue(key string) (*jira.Issue, error) {
+func (j *jiraClient) GetIssue(key string) (*jira.Issue, error) {
 	i, res, err := j.request(func() (interface{}, *jira.Response, error) {
 		// TODO(j-v2): Add query options
 		return j.client.Issue.Get(j.cfg.Context(), key, nil) //nolint:wrapcheck
@@ -202,42 +233,87 @@ func (j *realJiraClient) GetIssue(key string) (*jira.Issue, error) {
 // CreateIssue creates a new Jira issue according to the fields provided in
 // the provided issue object. It returns the created issue, with all the
 // fields provided (including e.g. ID and Key).
-func (j *realJiraClient) CreateIssue(issue *jira.Issue) (jira.Issue, error) {
-	i, res, err := j.request(func() (interface{}, *jira.Response, error) {
-		return j.client.Issue.Create(j.cfg.Context(), issue) //nolint:wrapcheck
-	})
-	if err != nil {
-		log.Errorf("Error creating Jira issue: %+v", err)
-		return jira.Issue{}, getErrorBody(res)
-	}
-	is, ok := i.(*jira.Issue)
-	if !ok {
-		log.Errorf("Create Jira issue did not return issue! Got: %v", i)
-		return jira.Issue{}, fmt.Errorf("create Jira issue failed: expected *jira.Issue; got %T", i) //nolint:goerr113
+func (j *jiraClient) CreateIssue(issue *jira.Issue) (jira.Issue, error) {
+	var newIssue *jira.Issue
+
+	// TODO(dry-run): Simplify logic
+	if !j.dryRun {
+		i, res, err := j.request(func() (interface{}, *jira.Response, error) {
+			return j.client.Issue.Create(j.cfg.Context(), issue) //nolint:wrapcheck
+		})
+		if err != nil {
+			log.Errorf("Error creating Jira issue: %+v", err)
+			return jira.Issue{}, getErrorBody(res)
+		}
+		is, ok := i.(*jira.Issue)
+		if !ok {
+			log.Errorf("Create Jira issue did not return issue! Got: %v", i)
+			return jira.Issue{}, fmt.Errorf("create Jira issue failed: expected *jira.Issue; got %T", i) //nolint:goerr113
+		}
+
+		newIssue = is
+	} else {
+		newIssue = issue
+		fields := newIssue.Fields
+
+		log.Info("")
+		log.Info("Create new Jira issue:")
+		log.Infof("  Summary: %s", fields.Summary)
+		log.Infof("  Description: %s", truncate(fields.Description, 50))
+		log.Infof("  GitHub ID: %d", fields.Unknowns[j.cfg.GetFieldKey(config.GitHubID)])
+		log.Infof("  GitHub Number: %d", fields.Unknowns[j.cfg.GetFieldKey(config.GitHubNumber)])
+		log.Infof("  Labels: %s", fields.Unknowns[j.cfg.GetFieldKey(config.GitHubLabels)])
+		log.Infof("  State: %s", fields.Unknowns[j.cfg.GetFieldKey(config.GitHubStatus)])
+		log.Infof("  Reporter: %s", fields.Unknowns[j.cfg.GetFieldKey(config.GitHubReporter)])
+		log.Info("")
 	}
 
-	return *is, nil
+	return *newIssue, nil
 }
 
 // UpdateIssue updates a given issue (identified by the Key field of the provided
 // issue object) with the fields on the provided issue. It returns the updated
 // issue as it exists on Jira.
-func (j *realJiraClient) UpdateIssue(issue *jira.Issue) (jira.Issue, error) {
-	i, res, err := j.request(func() (interface{}, *jira.Response, error) {
-		// TODO(j-v2): Add query options
-		return j.client.Issue.Update(j.cfg.Context(), issue, nil) //nolint:wrapcheck
-	})
-	if err != nil {
-		log.Errorf("Error updating Jira issue %s: %v", issue.Key, err)
-		return jira.Issue{}, getErrorBody(res)
-	}
-	is, ok := i.(*jira.Issue)
-	if !ok {
-		log.Errorf("Update Jira issue did not return issue! Got: %v", i)
-		return jira.Issue{}, fmt.Errorf("update Jira issue failed: expected *jira.Issue; got %T", i) //nolint:goerr113
+func (j *jiraClient) UpdateIssue(issue *jira.Issue) (jira.Issue, error) {
+	var newIssue *jira.Issue
+
+	// TODO(dry-run): Simplify logic
+	if !j.dryRun { //nolint:nestif // TODO(lint): complex nested blocks (nestif)
+		i, res, err := j.request(func() (interface{}, *jira.Response, error) {
+			// TODO(j-v2): Add query options
+			return j.client.Issue.Update(j.cfg.Context(), issue, nil) //nolint:wrapcheck
+		})
+		if err != nil {
+			log.Errorf("Error updating Jira issue %s: %v", issue.Key, err)
+			return jira.Issue{}, getErrorBody(res)
+		}
+		is, ok := i.(*jira.Issue)
+		if !ok {
+			log.Errorf("Update Jira issue did not return issue! Got: %v", i)
+			return jira.Issue{}, fmt.Errorf("update Jira issue failed: expected *jira.Issue; got %T", i) //nolint:goerr113
+		}
+
+		newIssue = is
+	} else {
+		newIssue = issue
+		fields := newIssue.Fields
+
+		log.Info("")
+		log.Infof("Update Jira issue %s:", issue.Key)
+		log.Infof("  Summary: %s", fields.Summary)
+		log.Infof("  Description: %s", truncate(fields.Description, 50))
+		key := j.cfg.GetFieldKey(config.GitHubLabels)
+		if labels, err := fields.Unknowns.String(key); err == nil {
+			log.Infof("  Labels: %s", labels)
+		}
+		key = j.cfg.GetFieldKey(config.GitHubStatus)
+		if state, err := fields.Unknowns.String(key); err == nil {
+			log.Infof("  State: %s", state)
+		}
+		log.Info("")
 	}
 
-	return *is, nil
+	return *newIssue, nil
 }
 
 // maxBodyLength is the maximum length of a Jira comment body, which is currently
@@ -246,7 +322,7 @@ const maxBodyLength = 1 << 15
 
 // CreateComment adds a comment to the provided Jira issue using the fields from
 // the provided GitHub comment. It then returns the created comment.
-func (j *realJiraClient) CreateComment(
+func (j *jiraClient) CreateComment(
 	issue *jira.Issue,
 	comment *gogh.IssueComment,
 	githubClient github.Client,
@@ -272,29 +348,50 @@ func (j *realJiraClient) CreateComment(
 		body = body[:maxBodyLength]
 	}
 
-	jComment := jira.Comment{
+	newComment := &jira.Comment{
 		Body: body,
 	}
 
-	com, res, err := j.request(func() (interface{}, *jira.Response, error) {
-		return j.client.Issue.AddComment(j.cfg.Context(), issue.ID, &jComment) //nolint:wrapcheck
-	})
-	if err != nil {
-		log.Errorf("Error creating Jira comment on issue %s. Error: %v", issue.Key, err)
-		return jira.Comment{}, getErrorBody(res)
+	// TODO(dry-run): Simplify logic
+	if !j.dryRun { //nolint:nestif // TODO(lint): complex nested blocks (nestif)
+		com, res, err := j.request(func() (interface{}, *jira.Response, error) {
+			return j.client.Issue.AddComment(j.cfg.Context(), issue.ID, newComment) //nolint:wrapcheck
+		})
+		if err != nil {
+			log.Errorf("Error creating Jira comment on issue %s. Error: %v", issue.Key, err)
+			return jira.Comment{}, getErrorBody(res)
+		}
+		co, ok := com.(*jira.Comment)
+		if !ok {
+			log.Errorf("Create Jira comment did not return comment! Got: %v", com)
+			return jira.Comment{}, fmt.Errorf( //nolint:goerr113
+				"create Jira comment failed: expected *jira.Comment; got %T",
+				com,
+			)
+		}
+
+		newComment = co
+	} else {
+		log.Info("")
+		log.Infof("Create comment on Jira issue %s:", issue.Key)
+		log.Infof("  GitHub ID: %d", comment.GetID())
+		if user.GetName() != "" {
+			log.Infof("  User: %s (%s)", user.GetLogin(), user.GetName())
+		} else {
+			log.Infof("  User: %s", user.GetLogin())
+		}
+		log.Infof("  Posted at: %s", comment.CreatedAt.Format(commentDateFormat))
+		log.Infof("  Body: %s", truncate(comment.GetBody(), 100))
+		log.Info("")
 	}
-	co, ok := com.(*jira.Comment)
-	if !ok {
-		log.Errorf("Create Jira comment did not return comment! Got: %v", com)
-		return jira.Comment{}, fmt.Errorf("create Jira comment failed: expected *jira.Comment; got %T", com) //nolint:goerr113
-	}
-	return *co, nil
+
+	return *newComment, nil
 }
 
 // UpdateComment updates a comment (identified by the `id` parameter) on a given
 // Jira with a new body from the fields of the given GitHub comment. It returns
 // the updated comment.
-func (j *realJiraClient) UpdateComment(
+func (j *jiraClient) UpdateComment(
 	issue *jira.Issue,
 	id string,
 	comment *gogh.IssueComment,
@@ -321,59 +418,76 @@ func (j *realJiraClient) UpdateComment(
 		body = body[:maxBodyLength]
 	}
 
-	// As it is, the Jira API we're using doesn't have any way to update comments natively.
-	// So, we have to build the request ourselves.
-	request := struct {
-		Body string `json:"body"`
-	}{
+	updatedComment := &jira.Comment{
+		ID:   id,
 		Body: body,
 	}
 
-	req, err := j.client.NewRequest(
-		j.cfg.Context(),
-		"PUT",
-		fmt.Sprintf("rest/api/2/issue/%s/comment/%s", issue.Key, id),
-		request,
-	)
-	if err != nil {
-		log.Errorf("Error creating comment update request: %s", err)
-		return jira.Comment{}, fmt.Errorf("creating comment update request: %w", err)
+	// TODO(dry-run): Simplify logic
+	if !j.dryRun { //nolint:nestif // TODO(lint): complex nested blocks (nestif)
+		// As it is, the Jira API we're using doesn't have any way to update comments natively.
+		// So, we have to build the request ourselves.
+		request := struct {
+			Body string `json:"body"`
+		}{
+			Body: body,
+		}
+
+		req, err := j.client.NewRequest(
+			j.cfg.Context(),
+			"PUT",
+			fmt.Sprintf("rest/api/2/issue/%s/comment/%s", issue.Key, id),
+			request,
+		)
+		if err != nil {
+			log.Errorf("Error creating comment update request: %s", err)
+			return jira.Comment{}, fmt.Errorf("creating comment update request: %w", err)
+		}
+
+		com, res, err := j.request(func() (interface{}, *jira.Response, error) {
+			res, err := j.client.Do(req, nil)
+			return nil, res, err //nolint:wrapcheck
+		})
+		if err != nil {
+			log.Errorf("Error updating comment: %+v", err)
+			return jira.Comment{}, getErrorBody(res)
+		}
+		co, ok := com.(*jira.Comment)
+		if !ok {
+			log.Errorf("Update Jira comment did not return comment! Got: %v", com)
+			return jira.Comment{}, fmt.Errorf( //nolint:goerr113
+				"update Jira comment failed: expected *jira.Comment; got %T",
+				com,
+			)
+		}
+
+		updatedComment = co
+	} else {
+		log.Info("")
+		log.Infof("Update Jira comment %s on issue %s:", id, issue.Key)
+		log.Infof("  GitHub ID: %d", comment.GetID())
+		if user.GetName() != "" {
+			log.Infof("  User: %s (%s)", user.GetLogin(), user.GetName())
+		} else {
+			log.Infof("  User: %s", user.GetLogin())
+		}
+		log.Infof("  Posted at: %s", comment.CreatedAt.Format(commentDateFormat))
+		log.Infof("  Body: %s", truncate(comment.GetBody(), 100))
+		log.Info("")
 	}
 
-	com, res, err := j.request(func() (interface{}, *jira.Response, error) {
-		res, err := j.client.Do(req, nil)
-		return nil, res, err //nolint:wrapcheck
-	})
-	if err != nil {
-		log.Errorf("Error updating comment: %+v", err)
-		return jira.Comment{}, getErrorBody(res)
-	}
-	co, ok := com.(*jira.Comment)
-	if !ok {
-		log.Errorf("Update Jira comment did not return comment! Got: %v", com)
-		return jira.Comment{}, fmt.Errorf("update Jira comment failed: expected *jira.Comment; got %T", com) //nolint:goerr113
-	}
-	return *co, nil
+	return *updatedComment, nil
 }
 
 // request executes a Jira request with exponential backoff, using the real
 // client.
-func (j *realJiraClient) request(f func() (interface{}, *jira.Response, error)) (interface{}, *jira.Response, error) {
+func (j *jiraClient) request(f func() (interface{}, *jira.Response, error)) (interface{}, *jira.Response, error) {
 	ret, resp, err := synchttp.NewJiraRequest(f, j.cfg.GetTimeout())
 	if err != nil {
 		return ret, resp, fmt.Errorf("request error: %w", err)
 	}
 
 	return ret, resp, nil
-}
-
-// dryrunJiraClient is an implementation of JiraClient which performs all
-// GET requests the same as the realJiraClient, but does not perform any
-// unsafe requests which may modify server data, instead printing out the
-// actions it is asked to perform without making the request.
-type dryrunJiraClient struct {
-	cfg    *config.Config
-	client *jira.Client
 }
 
 // newlineReplaceRegex is a regex to match both "\r\n" and just "\n" newline styles,
@@ -393,213 +507,6 @@ func truncate(s string, length int) string {
 		return s
 	}
 	return fmt.Sprintf("%s...", s[0:length])
-}
-
-// ListIssues returns a list of Jira issues on the configured project which
-// have GitHub IDs in the provided list. `ids` should be a comma-separated
-// list of GitHub IDs.
-//
-// This function is identical to that in realJiraClient.
-func (j *dryrunJiraClient) ListIssues(ids []int) ([]jira.Issue, error) {
-	jql := getJQLQuery(
-		j.cfg.GetProjectKey(),
-		j.cfg.GetFieldID(config.GitHubID),
-		ids,
-	)
-
-	ji, res, err := j.request(func() (interface{}, *jira.Response, error) {
-		// TODO(j-v2): Add query options
-		return j.client.Issue.Search(j.cfg.Context(), jql, nil) //nolint:wrapcheck
-	})
-	if err != nil {
-		log.Errorf("Error retrieving Jira issues: %+v", err)
-		return nil, getErrorBody(res)
-	}
-	jiraIssues, ok := ji.([]jira.Issue)
-	if !ok {
-		log.Errorf("Get Jira issues did not return issues! Got: %v", ji)
-		return nil, fmt.Errorf("get Jira issues failed: expected []jira.Issue; got %T", ji) //nolint:goerr113
-	}
-
-	var issues []jira.Issue
-	if len(ids) < maxJQLIssueLength {
-		// The issues were already filtered by our JQL, so use as is
-		issues = jiraIssues
-	} else {
-		// Filter only issues which have a defined GitHub ID in the list of IDs
-		for _, v := range jiraIssues {
-			if id, err := v.Fields.Unknowns.Int(j.cfg.GetFieldKey(config.GitHubID)); err == nil {
-				for _, idOpt := range ids {
-					if id == int64(idOpt) {
-						issues = append(issues, v)
-						break
-					}
-				}
-			}
-		}
-	}
-
-	return issues, nil
-}
-
-// GetIssue returns a single Jira issue within the configured project
-// according to the issue key (e.g. "PROJ-13").
-//
-// This function is identical to that in realJiraClient.
-func (j *dryrunJiraClient) GetIssue(key string) (*jira.Issue, error) {
-	i, res, err := j.request(func() (interface{}, *jira.Response, error) {
-		// TODO(j-v2): Add query options
-		return j.client.Issue.Get(j.cfg.Context(), key, nil) //nolint:wrapcheck
-	})
-	if err != nil {
-		log.Errorf("Error retrieving Jira issue: %+v", err)
-		return nil, getErrorBody(res)
-	}
-	issue, ok := i.(*jira.Issue)
-	if !ok {
-		log.Errorf("Get Jira issue did not return issue! Got %v", i)
-		return nil, fmt.Errorf("get Jira issue failed: expected *jira.Issue; got %T", i) //nolint:goerr113
-	}
-
-	return issue, nil
-}
-
-// CreateIssue prints out the fields that would be set on a new issue were
-// it to be created according to the provided issue object. It returns the
-// provided issue object as-is.
-func (j *dryrunJiraClient) CreateIssue(issue *jira.Issue) (jira.Issue, error) {
-	fields := issue.Fields
-
-	log.Info("")
-	log.Info("Create new Jira issue:")
-	log.Infof("  Summary: %s", fields.Summary)
-	log.Infof("  Description: %s", truncate(fields.Description, 50))
-	log.Infof("  GitHub ID: %d", fields.Unknowns[j.cfg.GetFieldKey(config.GitHubID)])
-	log.Infof("  GitHub Number: %d", fields.Unknowns[j.cfg.GetFieldKey(config.GitHubNumber)])
-	log.Infof("  Labels: %s", fields.Unknowns[j.cfg.GetFieldKey(config.GitHubLabels)])
-	log.Infof("  State: %s", fields.Unknowns[j.cfg.GetFieldKey(config.GitHubStatus)])
-	log.Infof("  Reporter: %s", fields.Unknowns[j.cfg.GetFieldKey(config.GitHubReporter)])
-	log.Info("")
-
-	return *issue, nil
-}
-
-// UpdateIssue prints out the fields that would be set on a Jira issue
-// (identified by issue.Key) were it to be updated according to the issue
-// object. It then returns the provided issue object as-is.
-func (j *dryrunJiraClient) UpdateIssue(issue *jira.Issue) (jira.Issue, error) {
-	fields := issue.Fields
-
-	log.Info("")
-	log.Infof("Update Jira issue %s:", issue.Key)
-	log.Infof("  Summary: %s", fields.Summary)
-	log.Infof("  Description: %s", truncate(fields.Description, 50))
-	key := j.cfg.GetFieldKey(config.GitHubLabels)
-	if labels, err := fields.Unknowns.String(key); err == nil {
-		log.Infof("  Labels: %s", labels)
-	}
-	key = j.cfg.GetFieldKey(config.GitHubStatus)
-	if state, err := fields.Unknowns.String(key); err == nil {
-		log.Infof("  State: %s", state)
-	}
-	log.Info("")
-
-	return *issue, nil
-}
-
-// CreateComment prints the body that would be set on a new comment if it were
-// to be created according to the fields of the provided GitHub comment. It then
-// returns a comment object containing the body that would be used.
-func (j *dryrunJiraClient) CreateComment(
-	issue *jira.Issue,
-	comment *gogh.IssueComment,
-	githubClient github.Client,
-) (jira.Comment, error) {
-	user, err := githubClient.GetUser(comment.User.GetLogin())
-	if err != nil {
-		return jira.Comment{}, fmt.Errorf("getting GitHub user: %w", err)
-	}
-
-	body := fmt.Sprintf("Comment (ID %d) from GitHub user %s", comment.GetID(), user.GetLogin())
-	if user.GetName() != "" {
-		body = fmt.Sprintf("%s (%s)", body, user.GetName())
-	}
-	body = fmt.Sprintf(
-		"%s at %s:\n\n%s",
-		body,
-		comment.CreatedAt.Format(commentDateFormat),
-		comment.GetBody(),
-	)
-
-	log.Info("")
-	log.Infof("Create comment on Jira issue %s:", issue.Key)
-	log.Infof("  GitHub ID: %d", comment.GetID())
-	if user.GetName() != "" {
-		log.Infof("  User: %s (%s)", user.GetLogin(), user.GetName())
-	} else {
-		log.Infof("  User: %s", user.GetLogin())
-	}
-	log.Infof("  Posted at: %s", comment.CreatedAt.Format(commentDateFormat))
-	log.Infof("  Body: %s", truncate(comment.GetBody(), 100))
-	log.Info("")
-
-	return jira.Comment{
-		Body: body,
-	}, nil
-}
-
-// UpdateComment prints the body that would be set on a comment were it to be
-// updated according to the provided GitHub comment. It then returns a comment
-// object containing the body that would be used.
-func (j *dryrunJiraClient) UpdateComment(
-	issue *jira.Issue,
-	id string,
-	comment *gogh.IssueComment,
-	githubClient github.Client,
-) (jira.Comment, error) {
-	user, err := githubClient.GetUser(comment.User.GetLogin())
-	if err != nil {
-		return jira.Comment{}, fmt.Errorf("getting GitHub user: %w", err)
-	}
-
-	body := fmt.Sprintf("Comment (ID %d) from GitHub user %s", comment.GetID(), user.GetLogin())
-	if user.GetName() != "" {
-		body = fmt.Sprintf("%s (%s)", body, user.GetName())
-	}
-	body = fmt.Sprintf(
-		"%s at %s:\n\n%s",
-		body,
-		comment.CreatedAt.Format(commentDateFormat),
-		comment.GetBody(),
-	)
-
-	log.Info("")
-	log.Infof("Update Jira comment %s on issue %s:", id, issue.Key)
-	log.Infof("  GitHub ID: %d", comment.GetID())
-	if user.GetName() != "" {
-		log.Infof("  User: %s (%s)", user.GetLogin(), user.GetName())
-	} else {
-		log.Infof("  User: %s", user.GetLogin())
-	}
-	log.Infof("  Posted at: %s", comment.CreatedAt.Format(commentDateFormat))
-	log.Infof("  Body: %s", truncate(comment.GetBody(), 100))
-	log.Info("")
-
-	return jira.Comment{
-		ID:   id,
-		Body: body,
-	}, nil
-}
-
-// request executes a Jira request with exponential backoff, using the dry-run
-// client.
-func (j *dryrunJiraClient) request(f func() (interface{}, *jira.Response, error)) (interface{}, *jira.Response, error) {
-	ret, resp, err := synchttp.NewJiraRequest(f, j.cfg.GetTimeout())
-	if err != nil {
-		return ret, resp, fmt.Errorf("request error: %w", err)
-	}
-
-	return ret, resp, nil
 }
 
 func getJQLQuery(projectKey, fieldID string, ids []int) string {

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -2,7 +2,7 @@
 
 ## Instructions
 
-Copy your private key which you have configured with JIRA into the
+Copy your private key which you have configured with Jira into the
 current directory.
 
 Fill out the config.yaml and secret.yaml files with the correct


### PR DESCRIPTION
- Fix Jira typo: "Jira", not "JIRA"
- jira: Move unexported functions to bottom of file
- jira: Remove `dryrunJiraClient` and merge into default methods

Signed-off-by: Stephen Augustus <foo@auggie.dev>