### PR TITLE
Comment fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/uwu-tools/gh-jira-issue-sync
 go 1.20
 
 require (
-	github.com/andygrunwald/go-jira/v2 v2.0.0-20221123211055-094697715517
+	github.com/andygrunwald/go-jira/v2 v2.0.0-20230325080157-2e11dffbdb9a
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/dghubble/oauth1 v0.7.2
 	github.com/fsnotify/fsnotify v1.6.0
@@ -30,7 +30,7 @@ require (
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/go-git/go-git/v5 v5.5.1 // indirect
-	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/uwu-tools/gh-jira-issue-sync
 
-go 1.19
+go 1.20
 
 require (
 	github.com/andygrunwald/go-jira/v2 v2.0.0-20221123211055-094697715517

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,15 @@ module github.com/uwu-tools/gh-jira-issue-sync
 
 go 1.20
 
+// TODO(deps): Revert the dependency on github.com/uwu-tools/go-jira/v2 once
+//             https://github.com/andygrunwald/go-jira/pull/640 has merged.
+//
+//             We temporarily forked andygrunwald/go-jira/v2 to integrate the
+//             changes made in #640, which fixes copying comments to Jira.
+//
+//             ref: https://github.com/uwu-tools/gh-jira-issue-sync/issues/62
+
 require (
-	github.com/andygrunwald/go-jira/v2 v2.0.0-20230325080157-2e11dffbdb9a
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/dghubble/oauth1 v0.7.2
 	github.com/fsnotify/fsnotify v1.6.0
@@ -12,6 +19,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.16.0
 	github.com/trivago/tgo v1.0.7
+	github.com/uwu-tools/go-jira/v2 v2.0.0-20230801175343-52f822b5cb80
 	golang.org/x/oauth2 v0.10.0
 	golang.org/x/term v0.10.0
 	sigs.k8s.io/release-sdk v0.9.8-0.20230104002921-c885fdbbb791

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,6 @@ github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 h1:ra2OtmuW0A
 github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4/go.mod h1:UBYPn8k0D56RtnR8RFQMjmh4KrZzWJ5o7Z9SYjossQ8=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
-github.com/andygrunwald/go-jira/v2 v2.0.0-20230325080157-2e11dffbdb9a h1:qSrg15WORClvHQfGe9RyFiDG52MeEpVj5qEs6O7QBE4=
-github.com/andygrunwald/go-jira/v2 v2.0.0-20230325080157-2e11dffbdb9a/go.mod h1:TrfsnL20VgD+KgEw4gbTYuSAPE8T1ZxjMCFBGgGvNvI=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -249,6 +247,8 @@ github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/trivago/tgo v1.0.7 h1:uaWH/XIy9aWYWpjm2CU3RpcqZXmX2ysQ9/Go+d9gyrM=
 github.com/trivago/tgo v1.0.7/go.mod h1:w4dpD+3tzNIIiIfkWWa85w5/B77tlvdZckQ+6PkFnhc=
+github.com/uwu-tools/go-jira/v2 v2.0.0-20230801175343-52f822b5cb80 h1:04lJNRh1PcNJLbidSGeExaAk4xWjqSTg75HYy5Tq1aU=
+github.com/uwu-tools/go-jira/v2 v2.0.0-20230801175343-52f822b5cb80/go.mod h1:mch2QHK8Jjd6Tot8qEVW329UUefiQjc92P4z98xJIKI=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 h1:ra2OtmuW0A
 github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4/go.mod h1:UBYPn8k0D56RtnR8RFQMjmh4KrZzWJ5o7Z9SYjossQ8=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
-github.com/andygrunwald/go-jira/v2 v2.0.0-20221123211055-094697715517 h1:Ad9ZdMo5iKMaVVOhuCdCl2FFZNKA/YeeK+nP9DU9vyU=
-github.com/andygrunwald/go-jira/v2 v2.0.0-20221123211055-094697715517/go.mod h1:8Wg9ZhNoktGf4TO0Bu7PdA25uWIHvkyG1qette1FKz8=
+github.com/andygrunwald/go-jira/v2 v2.0.0-20230325080157-2e11dffbdb9a h1:qSrg15WORClvHQfGe9RyFiDG52MeEpVj5qEs6O7QBE4=
+github.com/andygrunwald/go-jira/v2 v2.0.0-20230325080157-2e11dffbdb9a/go.mod h1:TrfsnL20VgD+KgEw4gbTYuSAPE8T1ZxjMCFBGgGvNvI=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -102,8 +102,8 @@ github.com/go-git/go-git/v5 v5.5.1/go.mod h1:uz5PQ3d0gz7mSgzZhSJToM6ALPaKCdSnl58
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
-github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
+github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,12 +29,12 @@ import (
 	"syscall"
 	"time"
 
-	jira "github.com/andygrunwald/go-jira/v2/cloud"
 	"github.com/dghubble/oauth1"
 	"github.com/fsnotify/fsnotify"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	jira "github.com/uwu-tools/go-jira/v2/cloud"
 	"golang.org/x/term"
 
 	"github.com/uwu-tools/gh-jira-issue-sync/internal/github"

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"time"
 
-	jira "github.com/andygrunwald/go-jira/v2/cloud"
 	"github.com/cenkalti/backoff/v4"
 	log "github.com/sirupsen/logrus"
+	jira "github.com/uwu-tools/go-jira/v2/cloud"
 )
 
 const retryBackoffRoundRatio = time.Millisecond / time.Nanosecond

--- a/internal/jira/comment/comment.go
+++ b/internal/jira/comment/comment.go
@@ -21,9 +21,9 @@ import (
 	"regexp"
 	"strconv"
 
-	gojira "github.com/andygrunwald/go-jira/v2/cloud"
 	gogh "github.com/google/go-github/v48/github"
 	log "github.com/sirupsen/logrus"
+	gojira "github.com/uwu-tools/go-jira/v2/cloud"
 
 	"github.com/uwu-tools/gh-jira-issue-sync/internal/config"
 	"github.com/uwu-tools/gh-jira-issue-sync/internal/github"

--- a/internal/jira/issue/issue.go
+++ b/internal/jira/issue/issue.go
@@ -21,10 +21,10 @@ import (
 	"strings"
 	"time"
 
-	gojira "github.com/andygrunwald/go-jira/v2/cloud"
 	gogh "github.com/google/go-github/v48/github"
 	log "github.com/sirupsen/logrus"
 	"github.com/trivago/tgo/tcontainer"
+	gojira "github.com/uwu-tools/go-jira/v2/cloud"
 
 	"github.com/uwu-tools/gh-jira-issue-sync/internal/config"
 	"github.com/uwu-tools/gh-jira-issue-sync/internal/github"

--- a/internal/jira/jira.go
+++ b/internal/jira/jira.go
@@ -23,9 +23,9 @@ import (
 	"regexp"
 	"strings"
 
-	jira "github.com/andygrunwald/go-jira/v2/cloud"
 	gogh "github.com/google/go-github/v48/github"
 	log "github.com/sirupsen/logrus"
+	jira "github.com/uwu-tools/go-jira/v2/cloud"
 
 	"github.com/uwu-tools/gh-jira-issue-sync/internal/config"
 	"github.com/uwu-tools/gh-jira-issue-sync/internal/github"


### PR DESCRIPTION
We temporarily forked andygrunwald/go-jira/v2 to integrate the
changes made in https://github.com/andygrunwald/go-jira/pull/640, which fixes copying comments to Jira.

ref: https://github.com/uwu-tools/go-jira/tree/comment-fixes, https://github.com/uwu-tools/gh-jira-issue-sync/issues/62

Thanks for testing this @lgecse!