### PR TITLE
Update Dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18.2@sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1
+FROM cgr.dev/chainguard/go:1.20
 
 WORKDIR /opt/gh-jira-issue-sync
 


### PR DESCRIPTION
Fixes https://github.com/uwu-tools/gh-jira-issue-sync/issues/4

**dev notes:**
- updated base image to cgr.dev/chainguard/go:1.20
