### PR TITLE
jira/comment: Improve regex matching

### DIFF
--- a/internal/jira/comment/comment.go
+++ b/internal/jira/comment/comment.go
@@ -34,7 +34,7 @@ import (
 // GitHub Comment ID (\1), the GitHub username (\2), the GitHub real name (\3, if it exists),
 // the time the comment was posted (\3 or \4), and the body of the comment (\4 or \5).
 var jCommentRegex = regexp.MustCompile(
-	`^Comment \[\(ID (\d+)\)\|.*?] from GitHub user \[(.+)\|.*?] \((.+)\) at (.+):\n\n(.+)$`,
+	`^Comment \[\(ID (\d+)\)\|.*?] from GitHub user \[(.+)\|.*?] (?:\(?(.+)\) |.*)at (.+):\n\n([\S\s]*)*?$`,
 )
 
 // jCommentIDRegex just matches the beginning of a generated Jira comment. It's a smaller,

--- a/internal/jira/comment/comment_test.go
+++ b/internal/jira/comment/comment_test.go
@@ -23,6 +23,17 @@ const testComment = `Comment [(ID 484163403)|https://github.com] from GitHub use
 
 Bla blibidy bloo bla`
 
+//nolint:lll
+const testCommentNewLine = `Comment [(ID 484163403)|https://github.com] from GitHub user [bilbo-baggins|https://github.com/bilbo-baggins] (Bilbo Baggins) at 16:27 PM, May 31 2020:
+
+Bla blibidy bloo bla
+bla bla`
+
+//nolint:lll
+const testCommentUnnamed = `Comment [(ID 123456789)|https://github.com] from GitHub user [smaug-bot|https://github.com/smaug-bot] at 16:27 PM, Jan 22 2021:
+
+rawr`
+
 func TestJiraCommentRegex(t *testing.T) {
 	fields := jCommentRegex.FindStringSubmatch(testComment)
 
@@ -48,5 +59,61 @@ func TestJiraCommentRegex(t *testing.T) {
 
 	if fields[5] != "Bla blibidy bloo bla" {
 		t.Fatalf("Expected field[5] = Bla blibidy bloo bla; Got field[5] = %s", fields[5])
+	}
+}
+
+func TestJiraCommentRegexNewLine(t *testing.T) {
+	fields := jCommentRegex.FindStringSubmatch(testCommentNewLine)
+
+	if len(fields) != 6 {
+		t.Fatalf("Regex failed to parse fields %v", fields)
+	}
+
+	if fields[1] != "484163403" {
+		t.Fatalf("Expected field[1] = 484163403; Got field[1] = %s", fields[1])
+	}
+
+	if fields[2] != "bilbo-baggins" {
+		t.Fatalf("Expected field[2] = bilbo-baggins; Got field[2] = %s", fields[2])
+	}
+
+	if fields[3] != "Bilbo Baggins" {
+		t.Fatalf("Expected field[3] = Bilbo Baggins; Got field[3] = %s", fields[3])
+	}
+
+	if fields[4] != "16:27 PM, May 31 2020" {
+		t.Fatalf("Expected field[4] = 16:27 PM, May 31 2020; Got field[4] = %s", fields[4])
+	}
+
+	if fields[5] != "Bla blibidy bloo bla\nbla bla" {
+		t.Fatalf("Expected field[5] = Bla blibidy bloo bla\nbla bla; Got field[5] = %s", fields[5])
+	}
+}
+
+func TestJiraCommentRegexUnnamed(t *testing.T) {
+	fields := jCommentRegex.FindStringSubmatch(testCommentUnnamed)
+
+	if len(fields) != 6 {
+		t.Fatalf("Regex failed to parse fields %v", fields)
+	}
+
+	if fields[1] != "123456789" {
+		t.Fatalf("Expected field[1] = 123456789; Got field[1] = %s", fields[1])
+	}
+
+	if fields[2] != "smaug-bot" {
+		t.Fatalf("Expected field[2] = smaug-bot; Got field[2] = %s", fields[2])
+	}
+
+	if fields[3] != "" {
+		t.Fatalf("Expected field[3] = ; Got field[3] = %s", fields[3])
+	}
+
+	if fields[4] != "16:27 PM, Jan 22 2021" {
+		t.Fatalf("Expected field[4] = 16:27 PM, Jan 22 2021; Got field[4] = %s", fields[4])
+	}
+
+	if fields[5] != "rawr" {
+		t.Fatalf("Expected field[5] = rawr; Got field[5] = %s", fields[5])
 	}
 }


### PR DESCRIPTION
Fixes #9 

Updated regular expression to match with:
- comments created by bots ( GitHubUser.GetName() can be empty, making the regex not match with the comment ) [internal/jira/jira.go ln337](https://github.com/uwu-tools/gh-jira-issue-sync/blob/ee1bd0b658ec9590f310db7b4a748055b6aae7fb/internal/jira/jira.go#L337)
- comments with having new lines in them 

Examples:

>Comment [(ID 1793589510)|https://github.com/openclarity/vmclarity/issues/632#issuecomment-1793589510] from GitHub user [github-actions[bot]|https://github.com/apps/github-actions] at 00:19 AM, November 5 2023:
>
>Thank you for your contribution! This issue has been automatically marked as `stale` because it has no recent activity in the last 60 days. It will be closed in 14 days, if no further activity occurs. If this issue is still relevant, please leave a comment to let us know, and the `stale` label will be automatically removed.

>Comment [(ID 1787170117)|https://github.com/openclarity/vmclarity/issues/812#issuecomment-1787170117] from GitHub user [lgecse|https://github.com/lgecse] (Laszlo Gecse) at 12:58 PM, October 31 2023:
>
>- Rename the PATH to INPUT
>- Have separate views based on the TYPE
>- In case of sbom it'd have the SIZE field 
>- In case of csv it'd have the number of items 
>- Make the list expandable, for cases when it'd be too long
